### PR TITLE
feat: read XCCONFIG_BASE64 in xcode-ios build

### DIFF
--- a/.github/workflows/build-xcode-ios.yml
+++ b/.github/workflows/build-xcode-ios.yml
@@ -87,6 +87,11 @@ on:
         required: false
         default: true
         type: boolean
+      build-number:
+        description: "Build number to set as CURRENT_PROJECT_VERSION"
+        required: false
+        default: ""
+        type: string
       # === BUILD CONFIGURATION ===
       working-directory:
         description: "Working directory"
@@ -215,6 +220,10 @@ jobs:
 
           if [ -n "${{ steps.setup-xcconfig.outputs.xcconfig-path }}" ]; then
             BUILD_CMD="$BUILD_CMD -xcconfig ${{ steps.setup-xcconfig.outputs.xcconfig-path }}"
+          fi
+
+          if [ -n "${{ inputs['build-number'] }}" ]; then
+            BUILD_CMD="$BUILD_CMD CURRENT_PROJECT_VERSION=${{ inputs['build-number'] }}"
           fi
 
           printf "Running: %s\n" "$BUILD_CMD"

--- a/.github/workflows/build-xcode-ios.yml
+++ b/.github/workflows/build-xcode-ios.yml
@@ -32,6 +32,7 @@
 #   PROVISIONING_PROFILE_BASE64: Base64-encoded provisioning profile
 #   KEYCHAIN_PASSWORD: Temporary keychain password
 #   EXPORT_OPTIONS_BASE64: Base64-encoded exportOptions.plist (optional, can use vars)
+#   XCCONFIG_BASE64: Base64-encoded xcconfig file with build settings overrides (optional)
 #
 # Required Permissions:
 #   contents: read  # Checkout code
@@ -178,6 +179,20 @@ jobs:
             "${{ inputs.project }}" \
             "${{ inputs.workspace }}" >> "$GITHUB_OUTPUT"
 
+      - name: Setup xcconfig from secret
+        id: setup-xcconfig
+        working-directory: ${{ inputs['working-directory'] }}
+        env:
+          XCCONFIG_BASE64: ${{ secrets.XCCONFIG_BASE64 }}
+        run: |
+          if [ -z "$XCCONFIG_BASE64" ]; then
+            printf "::notice::XCCONFIG_BASE64 secret not set — no xcconfig will be applied\n"
+          else
+            printf "%s" "$XCCONFIG_BASE64" | base64 --decode > "$RUNNER_TEMP/ci.xcconfig"
+            printf "xcconfig-path=%s/ci.xcconfig\n" "$RUNNER_TEMP" >> "$GITHUB_OUTPUT"
+            printf "::notice::xcconfig decoded from XCCONFIG_BASE64 secret\n"
+          fi
+
       - name: Archive app
         working-directory: ${{ inputs['working-directory'] }}
         run: |
@@ -197,6 +212,10 @@ jobs:
           BUILD_CMD="$BUILD_CMD -archivePath build/app.xcarchive"
           BUILD_CMD="$BUILD_CMD -destination '${{ inputs.destination }}'"
           BUILD_CMD="$BUILD_CMD -skipPackagePluginValidation"
+
+          if [ -n "${{ steps.setup-xcconfig.outputs.xcconfig-path }}" ]; then
+            BUILD_CMD="$BUILD_CMD -xcconfig ${{ steps.setup-xcconfig.outputs.xcconfig-path }}"
+          fi
 
           printf "Running: %s\n" "$BUILD_CMD"
           eval "$BUILD_CMD" | xcbeautify

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -343,6 +343,7 @@ jobs:
       export-options-var: ${{ matrix.artifact.config['export-options-var'] || 'EXPORT_OPTIONS_BASE64' }}
       artifact-name: ${{ matrix.artifact.name }}
       include-tag: false
+      build-number: ${{ matrix.artifact.config['build-number'] }}
       working-directory: ${{ matrix.artifact['working-directory'] }}
       macos-version: ${{ matrix.artifact.config['macos-version'] || 'macos-26' }}
       reusable-ci-ref: ${{ inputs.reusable-ci-ref }}


### PR DESCRIPTION
Allows setting additional build settings via a Base64 encoded .xcconfig file.

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
