### PR TITLE
fix: improve feedback in npm release dev flow

### DIFF
--- a/.github/workflows/publish-dev-npm.yml
+++ b/.github/workflows/publish-dev-npm.yml
@@ -13,10 +13,12 @@
 # How it works:
 # 1. Downloads pre-built artifacts from build-npm.yml
 # 2. Generates dev version: ${BASE_VERSION}-dev-${BRANCH}-${SHORT_SHA}
-# 3. Applies version to package.json (no git commit)
-# 4. Creates npm pack tarball
-# 5. Publishes to registry with 'dev' tag
-# 6. Uploads tarball as workflow artifact
+# 3. Checks if version already exists in registry (idempotent — same SHA = same content)
+# 4. If already published: logs warning, skips remaining steps, exits successfully
+# 5. Applies version to package.json (no git commit)
+# 6. Creates npm pack tarball
+# 7. Publishes to registry with 'dev' tag
+# 8. Uploads tarball as workflow artifact
 #
 # Security controls:
 # - Minimal - optimized for speed
@@ -94,6 +96,9 @@ on:
       tarball:
         description: "Tarball filename"
         value: ${{ jobs.build-and-publish.outputs.tarball }}
+      publish-status:
+        description: "Publish outcome: published or already-exists"
+        value: ${{ jobs.build-and-publish.outputs.publish-status }}
 permissions:
   contents: read
 jobs:
@@ -108,6 +113,7 @@ jobs:
       package-name: ${{ steps.meta.outputs.name }}
       package-version: ${{ steps.tags.outputs.dev_version }}
       tarball: ${{ steps.pack.outputs.tarball }}
+      publish-status: ${{ steps.check-registry.outputs.already_published == 'true' && 'already-exists' || 'published' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -169,7 +175,24 @@ jobs:
           DEV_VERSION=$(bash .github-shared/scripts/version/generate-dev-version.sh)
           printf "dev_version=%s\n" "${DEV_VERSION}" >> "$GITHUB_OUTPUT"
           printf "📦 Dev version: %s\n" "${DEV_VERSION}"
+      - name: Check if version already published
+        id: check-registry
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          NODE_AUTH_TOKEN: ${{ inputs['use-ci-token'] && secrets.GITHUB_TOKEN || secrets['registry-password'] }}
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          DEV_VERSION="${{ steps.tags.outputs.dev_version }}"
+          if npm view "${PKG_NAME}@${DEV_VERSION}" version --registry "${{ inputs.registry }}" 2>/dev/null; then
+            printf "::warning::Package %s@%s already exists in registry — skipping publish (same commit SHA)\n" \
+              "${PKG_NAME}" "${DEV_VERSION}"
+            printf "already_published=true\n" >> "$GITHUB_OUTPUT"
+          else
+            printf "Version %s not found in registry — will publish\n" "${DEV_VERSION}"
+            printf "already_published=false\n" >> "$GITHUB_OUTPUT"
+          fi
       - name: Apply dev version to package.json
+        if: steps.check-registry.outputs.already_published != 'true'
         working-directory: ${{ inputs.working-directory }}
         env:
           DEV_VERSION: ${{ steps.tags.outputs.dev_version }}
@@ -177,6 +200,7 @@ jobs:
           npm version "$DEV_VERSION" --no-git-tag-version --allow-same-version
           printf "Applied version: %s\n" "$(node -p "require('./package.json').version")"
       - name: Pack tarball
+        if: steps.check-registry.outputs.already_published != 'true'
         id: pack
         working-directory: ${{ inputs.working-directory }}
         run: |
@@ -185,12 +209,14 @@ jobs:
           printf "tarball=%s\n" "$FILE" >> "$GITHUB_OUTPUT"
           printf "Created: %s\n" "$FILE"
       - name: Upload tarball as artifact
+        if: steps.check-registry.outputs.already_published != 'true'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: npm-dev-package-${{ github.run_id }}
           path: ${{ inputs.working-directory }}/${{ steps.pack.outputs.tarball }}
           retention-days: 7
       - name: Publish to NPM registry
+        if: steps.check-registry.outputs.already_published != 'true'
         working-directory: ${{ inputs.working-directory }}
         env:
           NODE_AUTH_TOKEN: ${{ inputs['use-ci-token'] && secrets.GITHUB_TOKEN || secrets['registry-password'] }}

--- a/.github/workflows/release-dev-publish-stage.yml
+++ b/.github/workflows/release-dev-publish-stage.yml
@@ -99,4 +99,5 @@ jobs:
           CONTAINER_DIGEST: ${{ needs.build-dev-container.outputs.digest }}
           NPM_PACKAGE_NAME: ${{ needs.publish-npm-dev.outputs.package-name }}
           NPM_PACKAGE_VERSION: ${{ needs.publish-npm-dev.outputs.package-version }}
+          NPM_PUBLISH_STATUS: ${{ needs.publish-npm-dev.outputs.publish-status }}
         run: bash .github-shared/scripts/summary/write-dev-publish-stage-result.sh

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -196,6 +196,8 @@ Unlike the production flow, the dev path intentionally skips release creation, s
 It still benefits from one small control-plane interface job so later stage calls depend on compact dev context, runtime metadata, and policy payloads.
 The dev publish stage also exposes a compact artifact payload so the top-level workflow does not need to wire separate container and NPM leaf outputs directly.
 
+**Idempotent NPM publishing:** Dev versions are content-addressed (`{base}-dev-{branch}-{sha}`), so the same commit always produces the same version string. The `publish-dev-npm.yml` workflow checks the registry before publishing and skips with a warning if the version already exists. This makes re-runs safe — the pipeline succeeds without attempting to overwrite an immutable package.
+
 ```mermaid
 graph TD
     A[Push: develop or feature/*] --> B[release-dev-orchestrator.yml]

--- a/scripts/summary/write-dev-publish-stage-result.sh
+++ b/scripts/summary/write-dev-publish-stage-result.sh
@@ -32,8 +32,8 @@ main() {
   result_json="$(ci_stage_result_json "dev-publish" "$stage_result" "$stage_ran" "$targets_json" "project_type:${PROJECT_TYPE:-unknown}")"
 
   local artifacts_json
-  artifacts_json=$(printf '{"container_image":"%s","container_digest":"%s","npm_package_name":"%s","npm_package_version":"%s"}' \
-    "${CONTAINER_IMAGE:-}" "${CONTAINER_DIGEST:-}" "${NPM_PACKAGE_NAME:-}" "${NPM_PACKAGE_VERSION:-}")
+  artifacts_json=$(printf '{"container_image":"%s","container_digest":"%s","npm_package_name":"%s","npm_package_version":"%s","npm_publish_status":"%s"}' \
+    "${CONTAINER_IMAGE:-}" "${CONTAINER_DIGEST:-}" "${NPM_PACKAGE_NAME:-}" "${NPM_PACKAGE_VERSION:-}" "${NPM_PUBLISH_STATUS:-published}")
 
   ci_output "stage-ran" "$stage_ran"
   ci_output "stage-result" "$stage_result"

--- a/scripts/summary/write-dev-release-summary.sh
+++ b/scripts/summary/write-dev-release-summary.sh
@@ -10,7 +10,7 @@ source "$SCRIPT_DIR/../ci/env.sh"
 
 main() {
   local build_time short_sha container_status npm_status container_icon npm_icon
-  local container_image npm_package_name npm_package_version
+  local container_image npm_package_name npm_package_version npm_publish_status
 
   build_time=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
   short_sha="${RELEASE_SHA:0:7}"
@@ -19,6 +19,7 @@ main() {
   container_image="$(ci_json_value "$DEV_ARTIFACTS_JSON" container_image)"
   npm_package_name="$(ci_json_value "$DEV_ARTIFACTS_JSON" npm_package_name)"
   npm_package_version="$(ci_json_value "$DEV_ARTIFACTS_JSON" npm_package_version)"
+  npm_publish_status="$(ci_json_value "$DEV_ARTIFACTS_JSON" npm_publish_status)"
   container_icon="$(ci_status_icon "$container_status")"
   npm_icon="$(ci_status_icon "$npm_status")"
 
@@ -50,9 +51,15 @@ main() {
 EOF
 
   if [[ "$PROJECT_TYPE" == 'npm' ]]; then
-    cat >>"$(ci_summary_file)" <<EOF
+    if [[ "$npm_publish_status" == "already-exists" ]]; then
+      cat >>"$(ci_summary_file)" <<EOF
+| Publish NPM Package | $npm_icon (already published — skipped) |
+EOF
+    else
+      cat >>"$(ci_summary_file)" <<EOF
 | Publish NPM Package | $npm_icon |
 EOF
+    fi
   fi
 
   cat >>"$(ci_summary_file)" <<EOF
@@ -83,7 +90,23 @@ EOF
 
   if [[ "$PROJECT_TYPE" == 'npm' ]]; then
     if [[ -n "$npm_package_name" && -n "$npm_package_version" && "$npm_status" == 'success' ]]; then
-      cat >>"$(ci_summary_file)" <<EOF
+      if [[ "$npm_publish_status" == "already-exists" ]]; then
+        cat >>"$(ci_summary_file)" <<EOF
+
+### NPM Package
+> **Note:** Version already existed in registry — publish was skipped (same commit SHA).
+
+\`\`\`
+$npm_package_name@$npm_package_version
+\`\`\`
+
+\`\`\`bash
+npm install $npm_package_name@$npm_package_version
+npm install $npm_package_name@dev
+\`\`\`
+EOF
+      else
+        cat >>"$(ci_summary_file)" <<EOF
 
 ### NPM Package
 \`\`\`
@@ -95,6 +118,7 @@ npm install $npm_package_name@$npm_package_version
 npm install $npm_package_name@dev
 \`\`\`
 EOF
+      fi
     else
       cat >>"$(ci_summary_file)" <<EOF
 

--- a/tests/sbom/generate-sbom.bats
+++ b/tests/sbom/generate-sbom.bats
@@ -40,7 +40,7 @@ run_generate_sbom() {
 @test "generate-sbomdetects maven project from pom.xml" {
   create_maven_project
 
-  run_generate_sbom "auto" "source" "" "" "."
+  run_generate_sbom "auto" "source" "1.0.0" "myapp" "."
 
   assert_success
   assert_output --partial "Auto-detected project type: maven"

--- a/tests/summary/write-dev-publish-stage-result.bats
+++ b/tests/summary/write-dev-publish-stage-result.bats
@@ -199,4 +199,32 @@ teardown() {
   assert_output --partial '"container_digest":"sha256:abc123"'
   assert_output --partial '"npm_package_name":"@org/app"'
   assert_output --partial '"npm_package_version":"1.0.0-dev.1"'
+  assert_output --partial '"npm_publish_status":"published"'
+}
+
+@test "artifacts-json contains already-exists status when set" {
+  export PROJECT_TYPE="npm"
+  export BUILD_DEV_CONTAINER_RESULT="success"
+  export NPM_PACKAGE_NAME="@org/app"
+  export NPM_PACKAGE_VERSION="1.0.0-dev.1"
+  export NPM_PUBLISH_STATUS="already-exists"
+
+  run_script "summary/write-dev-publish-stage-result.sh"
+  assert_success
+
+  run get_github_output "artifacts-json"
+  assert_output --partial '"npm_publish_status":"already-exists"'
+}
+
+@test "artifacts-json defaults publish status to published when not set" {
+  export PROJECT_TYPE="npm"
+  export BUILD_DEV_CONTAINER_RESULT="success"
+  export NPM_PACKAGE_NAME="@org/app"
+  export NPM_PACKAGE_VERSION="1.0.0-dev.1"
+
+  run_script "summary/write-dev-publish-stage-result.sh"
+  assert_success
+
+  run get_github_output "artifacts-json"
+  assert_output --partial '"npm_publish_status":"published"'
 }

--- a/tests/summary/write-dev-release-summary.bats
+++ b/tests/summary/write-dev-release-summary.bats
@@ -22,7 +22,7 @@ setup() {
   export RELEASE_ACTOR="dev-user"
   export RELEASE_REPOSITORY="org/repo"
   export PUBLISH_STAGE_RESULT_JSON='{"targets":{"container":"success","npm":"success"}}'
-  export DEV_ARTIFACTS_JSON='{"container_image":"ghcr.io/org/app:dev","container_digest":"sha256:abc","npm_package_name":"@org/pkg","npm_package_version":"1.0.0-dev"}'
+  export DEV_ARTIFACTS_JSON='{"container_image":"ghcr.io/org/app:dev","container_digest":"sha256:abc","npm_package_name":"@org/pkg","npm_package_version":"1.0.0-dev","npm_publish_status":"published"}'
 }
 
 teardown() {
@@ -100,6 +100,27 @@ teardown() {
   run get_summary
   assert_output --partial "### NPM Package"
   assert_output --partial "Not published"
+}
+
+@test "write-dev-release-summary shows already-exists note when npm version was already published" {
+  export DEV_ARTIFACTS_JSON='{"container_image":"ghcr.io/org/app:dev","container_digest":"sha256:abc","npm_package_name":"@org/pkg","npm_package_version":"1.0.0-dev","npm_publish_status":"already-exists"}'
+
+  run_script "summary/write-dev-release-summary.sh"
+
+  assert_success
+  run get_summary
+  assert_output --partial "already existed in registry"
+  assert_output --partial "already published"
+  assert_output --partial "@org/pkg@1.0.0-dev"
+}
+
+@test "write-dev-release-summary does not show already-exists note on fresh publish" {
+  run_script "summary/write-dev-release-summary.sh"
+
+  assert_success
+  run get_summary
+  refute_output --partial "already existed"
+  assert_output --partial "@org/pkg@1.0.0-dev"
 }
 
 @test "write-dev-release-summary contains resources section with links" {


### PR DESCRIPTION
# Pull Request Description

Improves the npm release dev flow by adding more , earlier and clearer warnings, if a dev package already was released with the same sha.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
