### PR TITLE
Fix/missing jar SBOM

### DIFF
--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -112,6 +112,9 @@ jobs:
           MAVEN_PROFILE: ${{ inputs['profile'] }}
           SKIP_TESTS: ${{ inputs['skip-tests'] }}
         run: bash "${{ github.workspace }}/.github-shared/scripts/build/maven-library.sh"
+      - name: Generate Build SBOM
+        working-directory: ${{ inputs['working-directory'] }}
+        run: mvn org.cyclonedx:cyclonedx-maven-plugin:2.9.1:makeAggregateBom
       - name: List built artifacts
         working-directory: ${{ inputs['working-directory'] }}
         run: |
@@ -129,9 +132,11 @@ jobs:
             ${{ inputs['working-directory'] }}/target/*.jar
             ${{ inputs['working-directory'] }}/target/*.war
             ${{ inputs['working-directory'] }}/target/*.pom
+            ${{ inputs['working-directory'] }}/target/bom.json
             ${{ inputs['working-directory'] }}/**/target/*.jar
             ${{ inputs['working-directory'] }}/**/target/*.war
             ${{ inputs['working-directory'] }}/**/target/*.pom
+            ${{ inputs['working-directory'] }}/**/target/bom.json
             !${{ inputs['working-directory'] }}/target/original-*.jar
             !${{ inputs['working-directory'] }}/**/target/original-*.jar
           retention-days: 7

--- a/.github/workflows/release-create-github.yml
+++ b/.github/workflows/release-create-github.yml
@@ -189,7 +189,7 @@ jobs:
           # Use generic layer names (source, artifact) that work for all project types
           bash .github-shared/scripts/sbom/generate-sbom.sh \
             ${{ inputs['project-type'] }} \
-            "source,artifact" \
+            "source,build,analyzed-artifact" \
             "${{ steps.release-metadata.outputs.version-no-v }}" \
             "${{ steps.release-metadata.outputs.project-name }}"
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -195,7 +195,7 @@ Scripts for release artifact management and GitHub Release creation.
 | Script | Purpose |
 |--------|---------|
 | `create-github-release.sh` | Creates GitHub Release with artifacts, signatures, SBOMs, and checksums |
-| `create-sbom-zip.sh` | Packages all 3 SBOM layers (source, artifact, container) into ZIP; optionally GPG-signs |
+| `create-sbom-zip.sh` | Packages all 3 SBOM layers (source, analyzed-artifact, container) into ZIP; optionally GPG-signs |
 | `generate-checksums.sh` | Generates SHA256 checksums for all release artifacts |
 | `prepare-release-notes.sh` | Extracts release notes from changelog for the current version |
 | `resolve-artifact-name.sh` | Resolves artifact name from repository name or config |
@@ -230,7 +230,7 @@ bash generate-sbom.sh [PROJECT_TYPE] [LAYERS] [VERSION] [PROJECT_NAME] [WORKING_
 | Parameter | Default | Example |
 |-----------|---------|---------|
 | `PROJECT_TYPE` | `auto` | `maven`, `npm`, `gradle` |
-| `LAYERS` | `source` | `source,artifact,containerimage` |
+| `LAYERS` | `source` | `source,analyzed-artifact,analyzed-container` |
 | `VERSION` | auto-detect | `1.0.0` |
 | `PROJECT_NAME` | auto-detect | `my-app` |
 | `WORKING_DIR` | `.` | `/path/to/project` |
@@ -241,8 +241,8 @@ bash generate-sbom.sh [PROJECT_TYPE] [LAYERS] [VERSION] [PROJECT_NAME] [WORKING_
 | Layer | Parameter | Maven | NPM | Gradle |
 |-------|-----------|-------|-----|--------|
 | Source | `source` | `*-pom-sbom.*` | `*-package-sbom.*` | `*-gradle-sbom.*` |
-| Artifact | `artifact` | `*-jar-sbom.*` | `*-tararchive-sbom.*` | `*-jar-sbom.*` |
-| Container | `containerimage` | `*-container-sbom.*` | `*-container-sbom.*` | `*-container-sbom.*` |
+| Analyzed | `analyzed-artifact` | `*-jar-sbom.*` | `*-tararchive-sbom.*` | `*-jar-sbom.*` |
+| Container | `analyzed-container` | `*-container-sbom.*` | `*-container-sbom.*` | `*-container-sbom.*` |
 
 ---
 
@@ -351,5 +351,5 @@ Most projects use the orchestrators directly. For custom workflows:
 
 - run: |
     bash .reusable-ci/scripts/sbom/generate-sbom.sh \
-      maven "source,artifact" "$VERSION" "$PROJECT_NAME"
+      maven "source,analyzed-artifact" "$VERSION" "$PROJECT_NAME"
 ```

--- a/scripts/sbom/generate-container-sbom.sh
+++ b/scripts/sbom/generate-container-sbom.sh
@@ -36,7 +36,7 @@ main() {
     printf "No artifact dependencies - generating SBOM from container image only\n"
     bash "$SCRIPT_DIR/generate-sbom.sh" \
       "container" \
-      "containerimage" \
+      "analyzed-container" \
       "$VERSION" \
       "$PROJECT_NAME" \
       "." \
@@ -51,7 +51,7 @@ main() {
       printf "Generating SBOM for artifact type: %s\n" "$ARTIFACT_TYPE"
       bash "$SCRIPT_DIR/generate-sbom.sh" \
         "$ARTIFACT_TYPE" \
-        "containerimage" \
+        "analyzed-container" \
         "$VERSION" \
         "$PROJECT_NAME" \
         "." \

--- a/scripts/sbom/generate-sbom.sh
+++ b/scripts/sbom/generate-sbom.sh
@@ -4,7 +4,7 @@
 
 # Generate Software Bill of Materials (SBOMs) for different project types and layers
 # Supports: maven, npm, gradle, go, rust, python
-# Layers: source (dependency manifests), artifact (built binaries), containerimage
+# Layers: source (dependency manifests), artifact (built binaries), analyzed-container
 
 set -euo pipefail
 
@@ -284,13 +284,15 @@ generate_source_layer() {
 generate_artifact_layer_maven() {
   local name="$1" version="$2"
   local artifacts=()
+  local jar_patterns=(-name "${name}-*.jar" -o -name "${name}.jar")
+  local jar_excludes=(! -name "*-sources.jar" ! -name "*-javadoc.jar" ! -name "*-tests.jar" ! -name "original-*.jar")
 
   # Search for JAR files matching the artifact name (excluding sources, javadoc, tests, and original artifacts)
-  collect_artifacts artifacts find_artifacts "./release-artifacts" -name "${name}-*.jar" ! -name "*-sources.jar" ! -name "*-javadoc.jar" ! -name "*-tests.jar" ! -name "original-*.jar"
+  collect_artifacts artifacts find_artifacts "./release-artifacts" \( "${jar_patterns[@]}" \) "${jar_excludes[@]}"
 
-  [[ ${#artifacts[@]} -eq 0 ]] && collect_artifacts artifacts find_artifacts "./release-artifacts/target" -name "${name}-*.jar" ! -name "*-sources.jar" ! -name "*-javadoc.jar" ! -name "*-tests.jar" ! -name "original-*.jar"
+  [[ ${#artifacts[@]} -eq 0 ]] && collect_artifacts artifacts find_artifacts "./release-artifacts/target" \( "${jar_patterns[@]}" \) "${jar_excludes[@]}"
 
-  [[ ${#artifacts[@]} -eq 0 ]] && collect_artifacts artifacts find_artifacts "target" -name "${name}-*.jar" ! -name "*-sources.jar" ! -name "*-javadoc.jar" ! -name "*-tests.jar" ! -name "original-*.jar"
+  [[ ${#artifacts[@]} -eq 0 ]] && collect_artifacts artifacts find_artifacts "target" \( "${jar_patterns[@]}" \) "${jar_excludes[@]}"
 
   scan_artifacts "$name" "$version" "jar" "jar" "${artifacts[@]}" || log_warning "No JAR files found"
 }
@@ -365,6 +367,40 @@ generate_artifact_layer_python() {
     log_warning "No Python wheel/sdist found"
     log_info "Note: Source layer SBOM is usually sufficient"
   fi
+}
+
+generate_build_layer() {
+  local name="$1" version="$2"
+
+  log_section "Generating Build layer SBOMs..."
+  log_info "Project type: $PROJECT_TYPE"
+
+  case "$PROJECT_TYPE" in
+  maven) generate_build_layer_maven "$name" "$version" ;;
+  *) log_warning "Build SBOM not supported for project type: $PROJECT_TYPE" ;;
+  esac
+  printf "\n"
+}
+
+generate_build_layer_maven() {
+  local name="$1" version="$2"
+  local bom_file=""
+
+  for path in "./release-artifacts/target/bom.json" "./release-artifacts/bom.json" "target/bom.json"; do
+    if [[ -f "$path" ]]; then
+      bom_file="$path"
+      break
+    fi
+  done
+
+  if [[ -z "$bom_file" ]]; then
+    log_warning "No Maven Build SBOM (bom.json) found - run cyclonedx-maven-plugin during build"
+    return 1
+  fi
+
+  local output_file="${name}-${version}-build-sbom.cyclonedx.json"
+  cp "$bom_file" "$output_file"
+  log_success "$output_file"
 }
 
 generate_artifact_layer() {
@@ -479,10 +515,11 @@ main() {
     layer=$(printf "%s" "$layer" | xargs)
     case "$layer" in
     source) generate_source_layer "$project_name" "$version" ;;
-    artifact) generate_artifact_layer "$project_name" "$version" ;;
-    containerimage) generate_container_layer "$project_name" "$version" ;;
+    build) generate_build_layer "$project_name" "$version" ;;
+    analyzed-artifact) generate_artifact_layer "$project_name" "$version" ;;
+    analyzed-container) generate_container_layer "$project_name" "$version" ;;
     *)
-      log_warning "Unknown layer: $layer (valid: source, artifact, containerimage)"
+      log_warning "Unknown layer: $layer (valid: source, build, analyzed-artifact, analyzed-container)"
       return 1
       ;;
     esac

--- a/tests/sbom/generate-container-sbom.bats
+++ b/tests/sbom/generate-container-sbom.bats
@@ -39,7 +39,7 @@ teardown() {
   run_script "sbom/generate-container-sbom.sh" "" "1.0.0" "myapp" "ghcr.io/org/app@sha256:abc" "$MOCK_SBOM_DIR"
 
   assert_success
-  assert_output --partial "called: container containerimage 1.0.0 myapp . ghcr.io/org/app@sha256:abc"
+  assert_output --partial "called: container analyzed-container 1.0.0 myapp . ghcr.io/org/app@sha256:abc"
 }
 
 @test "generate-container-sbom mentions no artifact dependencies for empty types" {
@@ -57,7 +57,7 @@ teardown() {
   run_script "sbom/generate-container-sbom.sh" "maven" "1.0.0" "myapp" "ghcr.io/org/app@sha256:abc" "$MOCK_SBOM_DIR"
 
   assert_success
-  assert_output --partial "called: maven containerimage 1.0.0 myapp . ghcr.io/org/app@sha256:abc"
+  assert_output --partial "called: maven analyzed-container 1.0.0 myapp . ghcr.io/org/app@sha256:abc"
 }
 
 @test "generate-container-sbom mentions artifact type name" {
@@ -75,8 +75,8 @@ teardown() {
   run_script "sbom/generate-container-sbom.sh" "maven,npm" "2.0.0" "myapp" "ghcr.io/org/app@sha256:def" "$MOCK_SBOM_DIR"
 
   assert_success
-  assert_output --partial "called: maven containerimage 2.0.0 myapp . ghcr.io/org/app@sha256:def"
-  assert_output --partial "called: npm containerimage 2.0.0 myapp . ghcr.io/org/app@sha256:def"
+  assert_output --partial "called: maven analyzed-container 2.0.0 myapp . ghcr.io/org/app@sha256:def"
+  assert_output --partial "called: npm analyzed-container 2.0.0 myapp . ghcr.io/org/app@sha256:def"
 }
 
 @test "generate-container-sbom prints each artifact type name" {
@@ -96,7 +96,7 @@ teardown() {
   run_script "sbom/generate-container-sbom.sh" "npm" "3.5.1" "my-service" "ghcr.io/org/svc@sha256:xyz" "$MOCK_SBOM_DIR"
 
   assert_success
-  assert_output --partial "called: npm containerimage 3.5.1 my-service . ghcr.io/org/svc@sha256:xyz"
+  assert_output --partial "called: npm analyzed-container 3.5.1 my-service . ghcr.io/org/svc@sha256:xyz"
 }
 
 @test "generate-container-sbom passes correct image reference" {

--- a/tests/sbom/generate-sbom.bats
+++ b/tests/sbom/generate-sbom.bats
@@ -169,6 +169,43 @@ EOF
 }
 
 # =============================================================================
+# Build Layer Tests
+# =============================================================================
+
+@test "generate-sbomgenerates build layer for maven when bom.json exists" {
+  create_maven_project false
+  mkdir -p target
+  echo '{"bomFormat":"CycloneDX"}' > target/bom.json
+
+  run_generate_sbom "maven" "build" "1.0.0" "myapp" "."
+
+  assert_success
+  assert_output --partial "Generating Build layer"
+}
+
+@test "generate-sbomwarns when no bom.json found for maven build layer" {
+  create_maven_project false
+
+  run_generate_sbom "maven" "build" "1.0.0" "myapp" "."
+
+  assert_failure
+  assert_output --partial "No Maven Build SBOM"
+}
+
+@test "generate-sbombuild layer included in multi-layer run does not break packaging" {
+  create_maven_project true
+  mkdir -p target
+  echo '{"bomFormat":"CycloneDX"}' > target/bom.json
+
+  run_generate_sbom "maven" "source,build,analyzed-artifact" "1.0.0" "myapp" "."
+
+  assert_success
+  assert_output --partial "Generating Source layer"
+  assert_output --partial "Generating Build layer"
+  assert_output --partial "Generating Artifact layer"
+}
+
+# =============================================================================
 # Artifact Layer Tests
 # =============================================================================
 
@@ -177,7 +214,18 @@ EOF
   mkdir -p release-artifacts
   cp target/myapp-1.0.0.jar release-artifacts/
 
-  run_generate_sbom "maven" "artifact" "1.0.0" "myapp" "."
+  run_generate_sbom "maven" "analyzed-artifact" "1.0.0" "myapp" "."
+
+  assert_success
+  assert_output --partial "Generating Artifact layer"
+}
+
+@test "generate-sbomgenerates artifact layer for maven JAR without version suffix (finalName)" {
+  create_maven_project false
+  mkdir -p target
+  echo "mock jar" > target/myapp.jar
+
+  run_generate_sbom "maven" "analyzed-artifact" "1.0.0" "myapp" "."
 
   assert_success
   assert_output --partial "Generating Artifact layer"
@@ -186,7 +234,7 @@ EOF
 @test "generate-sbomwarns when no JARs found for maven" {
   create_maven_project false  # No JAR - script fails when no SBOMs generated
 
-  run_generate_sbom "maven" "artifact" "1.0.0" "myapp" "."
+  run_generate_sbom "maven" "analyzed-artifact" "1.0.0" "myapp" "."
 
   assert_failure  # Exits 1 when no SBOMs generated
   assert_output --partial "No JAR files found"
@@ -197,7 +245,7 @@ EOF
   create_npm_project
   echo "mock tarball" > myapp-1.0.0.tgz
 
-  run_generate_sbom "npm" "artifact" "1.0.0" "myapp" "."
+  run_generate_sbom "npm" "analyzed-artifact" "1.0.0" "myapp" "."
 
   assert_success
   assert_output --partial "Generating Artifact layer"
@@ -206,7 +254,7 @@ EOF
 @test "generate-sbomgenerates artifact layer for gradle" {
   create_gradle_project true
 
-  run_generate_sbom "gradle" "artifact" "1.0.0" "myapp" "."
+  run_generate_sbom "gradle" "analyzed-artifact" "1.0.0" "myapp" "."
 
   assert_success
   assert_output --partial "Generating Artifact layer"
@@ -217,7 +265,7 @@ EOF
 # =============================================================================
 
 @test "generate-sbomgenerates container layer when image provided" {
-  run_generate_sbom "maven" "containerimage" "1.0.0" "myapp" "." "ghcr.io/org/myapp:1.0.0"
+  run_generate_sbom "maven" "analyzed-container" "1.0.0" "myapp" "." "ghcr.io/org/myapp:1.0.0"
 
   assert_success
   assert_output --partial "Generating Container layer"
@@ -225,7 +273,7 @@ EOF
 }
 
 @test "generate-sbomskips container layer when no image provided" {
-  run_generate_sbom "maven" "containerimage" "1.0.0" "myapp" "." ""
+  run_generate_sbom "maven" "analyzed-container" "1.0.0" "myapp" "." ""
 
   assert_failure  # Exits 1 when no SBOMs generated
   assert_output --partial "No container image specified"
@@ -239,7 +287,7 @@ EOF
 @test "generate-sbomhandles comma-separated layers" {
   create_maven_project
 
-  run_generate_sbom "maven" "source,artifact" "1.0.0" "myapp" "."
+  run_generate_sbom "maven" "source,analyzed-artifact" "1.0.0" "myapp" "."
 
   assert_success
   assert_output --partial "Generating Source layer"
@@ -251,7 +299,7 @@ EOF
   mkdir -p release-artifacts
   cp target/myapp-1.0.0.jar release-artifacts/
 
-  run_generate_sbom "maven" "source,artifact,containerimage" "1.0.0" "myapp" "." "ghcr.io/org/myapp:1.0.0"
+  run_generate_sbom "maven" "source,analyzed-artifact,analyzed-container" "1.0.0" "myapp" "." "ghcr.io/org/myapp:1.0.0"
 
   assert_success
   assert_output --partial "Generating Source layer"


### PR DESCRIPTION
# Pull Request Description

**Bug**: When generating SBOMs, the code did not check for .jar files without version number suffixes. This caused missing JAR SBOMs for Maven projects using <finalName> to strip the version from the artifact filename (e.g. Spring Boot projects).

 **Refactor**: Renamed SBOM layer types to align with CISA taxonomy as defined by sbom.se:
  - artifact → analyzed-artifact
 - containerimage → analyzed-container

 These names reflect that the SBOMs are generated by analyzing static artifacts, not during the build process.

**Feat**: Added a build SBOM layer using the CycloneDX Maven plugin. This generates a true Build SBOM (per CISA taxonomy) during the Maven
  build step, capturing the exact resolved dependency tree at build time — without requiring changes to each project's pom.xml.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
