### PR TITLE
feat: sbom improvements

### DIFF
--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -112,6 +112,13 @@ jobs:
           MAVEN_PROFILE: ${{ inputs['profile'] }}
           SKIP_TESTS: ${{ inputs['skip-tests'] }}
         run: bash "${{ github.workspace }}/.github-shared/scripts/build/maven-library.sh"
+      - name: Generate Build SBOM
+        continue-on-error: true
+        working-directory: ${{ inputs['working-directory'] }}
+        # renovate: datasource=maven depName=org.cyclonedx:cyclonedx-maven-plugin
+        run: |
+          # shellcheck disable=SC2086
+          mvn $MAVEN_CLI_OPTS org.cyclonedx:cyclonedx-maven-plugin:2.9.1:makeAggregateBom
       - name: List built artifacts
         working-directory: ${{ inputs['working-directory'] }}
         run: |
@@ -129,9 +136,11 @@ jobs:
             ${{ inputs['working-directory'] }}/target/*.jar
             ${{ inputs['working-directory'] }}/target/*.war
             ${{ inputs['working-directory'] }}/target/*.pom
+            ${{ inputs['working-directory'] }}/target/bom.json
             ${{ inputs['working-directory'] }}/**/target/*.jar
             ${{ inputs['working-directory'] }}/**/target/*.war
             ${{ inputs['working-directory'] }}/**/target/*.pom
+            ${{ inputs['working-directory'] }}/**/target/bom.json
             !${{ inputs['working-directory'] }}/target/original-*.jar
             !${{ inputs['working-directory'] }}/**/target/original-*.jar
           retention-days: 7

--- a/.github/workflows/release-create-github.yml
+++ b/.github/workflows/release-create-github.yml
@@ -185,11 +185,11 @@ jobs:
       - name: Generate 3-Layer SBOMs
         if: &if_generate_sbom ${{ inputs['generate-sbom'] }}
         run: |
-          # Use SBOM generation script for source and analyzed-artifact layers
+          # Use SBOM generation script for source, build and analyzed-artifact layers
           # Use CISA taxonomy layer names that work for all project types
           bash .github-shared/scripts/sbom/generate-sbom.sh \
             ${{ inputs['project-type'] }} \
-            "source,analyzed-artifact" \
+            "source,build,analyzed-artifact" \
             "${{ steps.release-metadata.outputs.version-no-v }}" \
             "${{ steps.release-metadata.outputs.project-name }}"
 

--- a/.github/workflows/release-create-github.yml
+++ b/.github/workflows/release-create-github.yml
@@ -185,11 +185,11 @@ jobs:
       - name: Generate 3-Layer SBOMs
         if: &if_generate_sbom ${{ inputs['generate-sbom'] }}
         run: |
-          # Use SBOM generation script for source and artifact layers
-          # Use generic layer names (source, artifact) that work for all project types
+          # Use SBOM generation script for source and analyzed-artifact layers
+          # Use CISA taxonomy layer names that work for all project types
           bash .github-shared/scripts/sbom/generate-sbom.sh \
             ${{ inputs['project-type'] }} \
-            "source,artifact" \
+            "source,analyzed-artifact" \
             "${{ steps.release-metadata.outputs.version-no-v }}" \
             "${{ steps.release-metadata.outputs.project-name }}"
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -195,7 +195,7 @@ Scripts for release artifact management and GitHub Release creation.
 | Script | Purpose |
 |--------|---------|
 | `create-github-release.sh` | Creates GitHub Release with artifacts, signatures, SBOMs, and checksums |
-| `create-sbom-zip.sh` | Packages all 3 SBOM layers (source, artifact, container) into ZIP; optionally GPG-signs |
+| `create-sbom-zip.sh` | Packages all SBOM layers (source, analyzed-artifact, analyzed-container) into ZIP; optionally GPG-signs |
 | `generate-checksums.sh` | Generates SHA256 checksums for all release artifacts |
 | `prepare-release-notes.sh` | Extracts release notes from changelog for the current version |
 | `resolve-artifact-name.sh` | Resolves artifact name from repository name or config |
@@ -230,7 +230,7 @@ bash generate-sbom.sh [PROJECT_TYPE] [LAYERS] [VERSION] [PROJECT_NAME] [WORKING_
 | Parameter | Default | Example |
 |-----------|---------|---------|
 | `PROJECT_TYPE` | `auto` | `maven`, `npm`, `gradle` |
-| `LAYERS` | `source` | `source,artifact,containerimage` |
+| `LAYERS` | `source` | `source,analyzed-artifact,analyzed-container` |
 | `VERSION` | auto-detect | `1.0.0` |
 | `PROJECT_NAME` | auto-detect | `my-app` |
 | `WORKING_DIR` | `.` | `/path/to/project` |
@@ -241,8 +241,8 @@ bash generate-sbom.sh [PROJECT_TYPE] [LAYERS] [VERSION] [PROJECT_NAME] [WORKING_
 | Layer | Parameter | Maven | NPM | Gradle |
 |-------|-----------|-------|-----|--------|
 | Source | `source` | `*-pom-sbom.*` | `*-package-sbom.*` | `*-gradle-sbom.*` |
-| Artifact | `artifact` | `*-jar-sbom.*` | `*-tararchive-sbom.*` | `*-jar-sbom.*` |
-| Container | `containerimage` | `*-container-sbom.*` | `*-container-sbom.*` | `*-container-sbom.*` |
+| Analyzed Artifact | `analyzed-artifact` | `*-jar-sbom.*` | `*-tararchive-sbom.*` | `*-jar-sbom.*` |
+| Analyzed Container | `analyzed-container` | `*-container-sbom.*` | `*-container-sbom.*` | `*-container-sbom.*` |
 
 ---
 
@@ -351,5 +351,5 @@ Most projects use the orchestrators directly. For custom workflows:
 
 - run: |
     bash .reusable-ci/scripts/sbom/generate-sbom.sh \
-      maven "source,artifact" "$VERSION" "$PROJECT_NAME"
+      maven "source,analyzed-artifact" "$VERSION" "$PROJECT_NAME"
 ```

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -230,7 +230,7 @@ bash generate-sbom.sh [PROJECT_TYPE] [LAYERS] [VERSION] [PROJECT_NAME] [WORKING_
 | Parameter | Default | Example |
 |-----------|---------|---------|
 | `PROJECT_TYPE` | `auto` | `maven`, `npm`, `gradle` |
-| `LAYERS` | `source` | `source,analyzed-artifact,analyzed-container` |
+| `LAYERS` | `source` | `source,build,analyzed-artifact,analyzed-container` |
 | `VERSION` | auto-detect | `1.0.0` |
 | `PROJECT_NAME` | auto-detect | `my-app` |
 | `WORKING_DIR` | `.` | `/path/to/project` |
@@ -241,6 +241,7 @@ bash generate-sbom.sh [PROJECT_TYPE] [LAYERS] [VERSION] [PROJECT_NAME] [WORKING_
 | Layer | Parameter | Maven | NPM | Gradle |
 |-------|-----------|-------|-----|--------|
 | Source | `source` | `*-pom-sbom.*` | `*-package-sbom.*` | `*-gradle-sbom.*` |
+| Build | `build` | `*-build-sbom.cyclonedx.json` | - | - |
 | Analyzed Artifact | `analyzed-artifact` | `*-jar-sbom.*` | `*-tararchive-sbom.*` | `*-jar-sbom.*` |
 | Analyzed Container | `analyzed-container` | `*-container-sbom.*` | `*-container-sbom.*` | `*-container-sbom.*` |
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -199,22 +199,24 @@ Layer names align with [CISA SBOM Types](https://www.cisa.gov/resources-tools/re
 | CISA Type | Layer name | Tool | Maven | NPM | Gradle | Go / Rust / Python |
 |-----------|-----------|------|-------|-----|--------|--------------------|
 | **Source** | `source` | Syft | `pom.xml` | `package.json` | `build.gradle` | `go.mod` / `Cargo.toml` / `pyproject.toml` |
+| **Build** | `build` | CycloneDX plugin | cyclonedx-maven-plugin | - | - | - |
 | **Analyzed** | `analyzed-artifact` | Syft | JAR files | `.tgz` tarball | JAR files | binaries / wheels |
 | **Analyzed** | `analyzed-container` | Syft | container image | container image | container image | container image |
 
 **Not implemented:** Design, Deployed, and Runtime SBOM types are outside CI/CD scope.
 
-### 3-Layer SBOM Architecture
+### 4-Layer SBOM Architecture
 
-Every release includes **three layers** of SBOMs, each in **two formats** (SPDX + CycloneDX):
+Every release includes up to **four layers** of SBOMs, each in **two formats** (SPDX + CycloneDX):
 
 | Layer | Source | Captures | Use Case | Formats |
 |-------|--------|----------|----------|---------|
 | **Source** | `pom.xml`, `build.gradle`, `package.json` | Declared dependencies + transitive dependencies | License compliance, dependency analysis, build-time security | SPDX 2.3, CycloneDX 1.6 |
+| **Build** | CycloneDX Maven plugin (`bom.json`) | Precise build-time dependency resolution | Build reproducibility, dependency verification | CycloneDX 1.6 |
 | **Analyzed Artifact** | JAR binaries (may be multiple) | Actual packaged libraries (including shaded deps) | Runtime dependency verification, binary analysis | SPDX 2.3, CycloneDX 1.6 |
 | **Analyzed Container** | Container image | OS packages, JRE, runtime environment | Deployment security, runtime vulnerability scanning | SPDX 2.3, CycloneDX 1.6 |
 
-**Total SBOMs per release:** 6-10+ files (3+ layers × 2 formats, more if multiple JARs)
+**Total SBOMs per release:** 7-11+ files (4 layers × 2 formats, more if multiple JARs)
 
 ### SBOM Naming Convention
 
@@ -367,8 +369,8 @@ syft packages PROJECT-VERSION-pom-sbom.cyclonedx.json -o json | \
 
 SBOMs are generated automatically during the release process:
 
-1. **Container Build** → Generates container SBOM (2 formats)
-2. **Maven/NPM Build** → Generates POM + JAR SBOMs (4 formats)
+1. **Container Build** → Generates analyzed-container SBOM (2 formats)
+2. **Maven/NPM Build** → Generates source + build + analyzed-artifact SBOMs
 3. **Release Step** → Downloads container SBOM, packages all SBOMs into ZIP
 4. **Signing** → GPG signs SBOM archive and checksums
 5. **Upload** → ZIP archive to GitHub Release

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -192,15 +192,27 @@ Artifact verification prevents tampering and validates authenticity in CI/CD pip
 
 DiggSweden workflows generate comprehensive multi-layer SBOMs for complete supply chain transparency and compliance with international standards.
 
+### CISA SBOM Type Mapping
+
+Layer names align with [CISA SBOM Types](https://www.cisa.gov/resources-tools/resources/types-software-bill-materials-sbom) (April 2023).
+
+| CISA Type | Layer name | Tool | Maven | NPM | Gradle | Go / Rust / Python |
+|-----------|-----------|------|-------|-----|--------|--------------------|
+| **Source** | `source` | Syft | `pom.xml` | `package.json` | `build.gradle` | `go.mod` / `Cargo.toml` / `pyproject.toml` |
+| **Analyzed** | `analyzed-artifact` | Syft | JAR files | `.tgz` tarball | JAR files | binaries / wheels |
+| **Analyzed** | `analyzed-container` | Syft | container image | container image | container image | container image |
+
+**Not implemented:** Design, Deployed, and Runtime SBOM types are outside CI/CD scope.
+
 ### 3-Layer SBOM Architecture
 
 Every release includes **three layers** of SBOMs, each in **two formats** (SPDX + CycloneDX):
 
 | Layer | Source | Captures | Use Case | Formats |
 |-------|--------|----------|----------|---------|
-| **POM** | `pom.xml`, `build.gradle`, `package.json` | Declared dependencies + transitive dependencies | License compliance, dependency analysis, build-time security | SPDX 2.3, CycloneDX 1.6 |
-| **JAR** | JAR binaries (may be multiple) | Actual packaged libraries (including shaded deps) | Runtime dependency verification, binary analysis | SPDX 2.3, CycloneDX 1.6 |
-| **Container** | Container image | OS packages, JRE, runtime environment | Deployment security, runtime vulnerability scanning | SPDX 2.3, CycloneDX 1.6 |
+| **Source** | `pom.xml`, `build.gradle`, `package.json` | Declared dependencies + transitive dependencies | License compliance, dependency analysis, build-time security | SPDX 2.3, CycloneDX 1.6 |
+| **Analyzed Artifact** | JAR binaries (may be multiple) | Actual packaged libraries (including shaded deps) | Runtime dependency verification, binary analysis | SPDX 2.3, CycloneDX 1.6 |
+| **Analyzed Container** | Container image | OS packages, JRE, runtime environment | Deployment security, runtime vulnerability scanning | SPDX 2.3, CycloneDX 1.6 |
 
 **Total SBOMs per release:** 6-10+ files (3+ layers × 2 formats, more if multiple JARs)
 
@@ -379,6 +391,7 @@ SBOMs are generated automatically during the release process:
 
 - [NTIA SBOM Minimum Elements](https://www.ntia.gov/sites/default/files/publications/sbom_minimum_elements_report_0.pdf)
 - [CISA SBOM Guidance](https://www.cisa.gov/sbom)
+- [CISA SBOM Types](https://www.cisa.gov/resources-tools/resources/types-software-bill-materials-sbom)
 - [EU Cyber Resilience Act](https://digital-strategy.ec.europa.eu/en/policies/cyber-resilience-act)
 - [SPDX Specification 2.3](https://spdx.github.io/spdx-spec/v2.3/)
 - [CycloneDX Specification 1.6](https://cyclonedx.org/specification/overview/)

--- a/scripts/sbom/generate-container-sbom.sh
+++ b/scripts/sbom/generate-container-sbom.sh
@@ -36,7 +36,7 @@ main() {
     printf "No artifact dependencies - generating SBOM from container image only\n"
     bash "$SCRIPT_DIR/generate-sbom.sh" \
       "container" \
-      "containerimage" \
+      "analyzed-container" \
       "$VERSION" \
       "$PROJECT_NAME" \
       "." \
@@ -51,7 +51,7 @@ main() {
       printf "Generating SBOM for artifact type: %s\n" "$ARTIFACT_TYPE"
       bash "$SCRIPT_DIR/generate-sbom.sh" \
         "$ARTIFACT_TYPE" \
-        "containerimage" \
+        "analyzed-container" \
         "$VERSION" \
         "$PROJECT_NAME" \
         "." \

--- a/scripts/sbom/generate-sbom.sh
+++ b/scripts/sbom/generate-sbom.sh
@@ -4,7 +4,7 @@
 
 # Generate Software Bill of Materials (SBOMs) for different project types and layers
 # Supports: maven, npm, gradle, go, rust, python
-# Layers: source (dependency manifests), artifact (built binaries), containerimage
+# Layers: source (dependency manifests), analyzed-artifact (built binaries), analyzed-container
 
 set -euo pipefail
 
@@ -481,10 +481,10 @@ main() {
     layer=$(printf "%s" "$layer" | xargs)
     case "$layer" in
     source) generate_source_layer "$project_name" "$version" ;;
-    artifact) generate_artifact_layer "$project_name" "$version" ;;
-    containerimage) generate_container_layer "$project_name" "$version" ;;
+    analyzed-artifact) generate_artifact_layer "$project_name" "$version" ;;
+    analyzed-container) generate_container_layer "$project_name" "$version" ;;
     *)
-      log_warning "Unknown layer: $layer (valid: source, artifact, containerimage)"
+      log_warning "Unknown layer: $layer (valid: source, analyzed-artifact, analyzed-container)"
       return 1
       ;;
     esac

--- a/scripts/sbom/generate-sbom.sh
+++ b/scripts/sbom/generate-sbom.sh
@@ -369,6 +369,40 @@ generate_artifact_layer_python() {
   fi
 }
 
+generate_build_layer() {
+  local name="$1" version="$2"
+
+  log_section "Generating Build layer SBOMs..."
+  log_info "Project type: $PROJECT_TYPE"
+
+  case "$PROJECT_TYPE" in
+  maven) generate_build_layer_maven "$name" "$version" ;;
+  *) log_warning "Build SBOM not supported for project type: $PROJECT_TYPE" ;;
+  esac
+  printf "\n"
+}
+
+generate_build_layer_maven() {
+  local name="$1" version="$2"
+  local bom_file=""
+
+  for path in "./release-artifacts/target/bom.json" "./release-artifacts/bom.json" "target/bom.json"; do
+    if [[ -f "$path" ]]; then
+      bom_file="$path"
+      break
+    fi
+  done
+
+  if [[ -z "$bom_file" ]]; then
+    log_warning "No Maven Build SBOM (bom.json) found - run cyclonedx-maven-plugin during build"
+    return
+  fi
+
+  local output_file="${name}-${version}-build-sbom.cyclonedx.json"
+  cp "$bom_file" "$output_file"
+  log_success "$output_file"
+}
+
 generate_artifact_layer() {
   local name="$1" version="$2"
 
@@ -481,10 +515,11 @@ main() {
     layer=$(printf "%s" "$layer" | xargs)
     case "$layer" in
     source) generate_source_layer "$project_name" "$version" ;;
+    build) generate_build_layer "$project_name" "$version" ;;
     analyzed-artifact) generate_artifact_layer "$project_name" "$version" ;;
     analyzed-container) generate_container_layer "$project_name" "$version" ;;
     *)
-      log_warning "Unknown layer: $layer (valid: source, analyzed-artifact, analyzed-container)"
+      log_warning "Unknown layer: $layer (valid: source, build, analyzed-artifact, analyzed-container)"
       return 1
       ;;
     esac

--- a/scripts/sbom/generate-sbom.sh
+++ b/scripts/sbom/generate-sbom.sh
@@ -284,13 +284,15 @@ generate_source_layer() {
 generate_artifact_layer_maven() {
   local name="$1" version="$2"
   local artifacts=()
+  local jar_patterns=(-name "${name}-*.jar" -o -name "${name}.jar")
+  local jar_excludes=(! -name "*-sources.jar" ! -name "*-javadoc.jar" ! -name "*-tests.jar" ! -name "original-*.jar")
 
   # Search for JAR files matching the artifact name (excluding sources, javadoc, tests, and original artifacts)
-  collect_artifacts artifacts find_artifacts "./release-artifacts" -name "${name}-*.jar" ! -name "*-sources.jar" ! -name "*-javadoc.jar" ! -name "*-tests.jar" ! -name "original-*.jar"
+  collect_artifacts artifacts find_artifacts "./release-artifacts" \( "${jar_patterns[@]}" \) "${jar_excludes[@]}"
 
-  [[ ${#artifacts[@]} -eq 0 ]] && collect_artifacts artifacts find_artifacts "./release-artifacts/target" -name "${name}-*.jar" ! -name "*-sources.jar" ! -name "*-javadoc.jar" ! -name "*-tests.jar" ! -name "original-*.jar"
+  [[ ${#artifacts[@]} -eq 0 ]] && collect_artifacts artifacts find_artifacts "./release-artifacts/target" \( "${jar_patterns[@]}" \) "${jar_excludes[@]}"
 
-  [[ ${#artifacts[@]} -eq 0 ]] && collect_artifacts artifacts find_artifacts "target" -name "${name}-*.jar" ! -name "*-sources.jar" ! -name "*-javadoc.jar" ! -name "*-tests.jar" ! -name "original-*.jar"
+  [[ ${#artifacts[@]} -eq 0 ]] && collect_artifacts artifacts find_artifacts "target" \( "${jar_patterns[@]}" \) "${jar_excludes[@]}"
 
   scan_artifacts "$name" "$version" "jar" "jar" "${artifacts[@]}" || log_warning "No JAR files found"
 }

--- a/tests/sbom/generate-container-sbom.bats
+++ b/tests/sbom/generate-container-sbom.bats
@@ -39,7 +39,7 @@ teardown() {
   run_script "sbom/generate-container-sbom.sh" "" "1.0.0" "myapp" "ghcr.io/org/app@sha256:abc" "$MOCK_SBOM_DIR"
 
   assert_success
-  assert_output --partial "called: container containerimage 1.0.0 myapp . ghcr.io/org/app@sha256:abc"
+  assert_output --partial "called: container analyzed-container 1.0.0 myapp . ghcr.io/org/app@sha256:abc"
 }
 
 @test "generate-container-sbom mentions no artifact dependencies for empty types" {
@@ -57,7 +57,7 @@ teardown() {
   run_script "sbom/generate-container-sbom.sh" "maven" "1.0.0" "myapp" "ghcr.io/org/app@sha256:abc" "$MOCK_SBOM_DIR"
 
   assert_success
-  assert_output --partial "called: maven containerimage 1.0.0 myapp . ghcr.io/org/app@sha256:abc"
+  assert_output --partial "called: maven analyzed-container 1.0.0 myapp . ghcr.io/org/app@sha256:abc"
 }
 
 @test "generate-container-sbom mentions artifact type name" {
@@ -75,8 +75,8 @@ teardown() {
   run_script "sbom/generate-container-sbom.sh" "maven,npm" "2.0.0" "myapp" "ghcr.io/org/app@sha256:def" "$MOCK_SBOM_DIR"
 
   assert_success
-  assert_output --partial "called: maven containerimage 2.0.0 myapp . ghcr.io/org/app@sha256:def"
-  assert_output --partial "called: npm containerimage 2.0.0 myapp . ghcr.io/org/app@sha256:def"
+  assert_output --partial "called: maven analyzed-container 2.0.0 myapp . ghcr.io/org/app@sha256:def"
+  assert_output --partial "called: npm analyzed-container 2.0.0 myapp . ghcr.io/org/app@sha256:def"
 }
 
 @test "generate-container-sbom prints each artifact type name" {
@@ -96,7 +96,7 @@ teardown() {
   run_script "sbom/generate-container-sbom.sh" "npm" "3.5.1" "my-service" "ghcr.io/org/svc@sha256:xyz" "$MOCK_SBOM_DIR"
 
   assert_success
-  assert_output --partial "called: npm containerimage 3.5.1 my-service . ghcr.io/org/svc@sha256:xyz"
+  assert_output --partial "called: npm analyzed-container 3.5.1 my-service . ghcr.io/org/svc@sha256:xyz"
 }
 
 @test "generate-container-sbom passes correct image reference" {

--- a/tests/sbom/generate-sbom.bats
+++ b/tests/sbom/generate-sbom.bats
@@ -169,6 +169,57 @@ EOF
 }
 
 # =============================================================================
+# Build Layer Tests
+# =============================================================================
+
+@test "generate-sbomgenerates build layer for maven when bom.json exists" {
+  create_maven_project false
+  mkdir -p target
+  echo '{"bomFormat":"CycloneDX"}' > target/bom.json
+
+  run_generate_sbom "maven" "build" "1.0.0" "myapp" "."
+
+  assert_success
+  assert_output --partial "Generating Build layer"
+}
+
+@test "generate-sbomwarns when no bom.json found for maven build layer" {
+  create_maven_project false
+
+  run_generate_sbom "maven" "build" "1.0.0" "myapp" "."
+
+  assert_failure  # Exits 1 when no SBOMs generated (summary check)
+  assert_output --partial "No Maven Build SBOM"
+  assert_output --partial "No SBOM files generated"
+}
+
+@test "generate-sbombuild layer included in multi-layer run does not break packaging" {
+  create_maven_project true
+  mkdir -p target
+  echo '{"bomFormat":"CycloneDX"}' > target/bom.json
+
+  run_generate_sbom "maven" "source,build,analyzed-artifact" "1.0.0" "myapp" "."
+
+  assert_success
+  assert_output --partial "Generating Source layer"
+  assert_output --partial "Generating Build layer"
+  assert_output --partial "Generating Artifact layer"
+}
+
+@test "generate-sbommissing build bom.json does not block other layers" {
+  create_maven_project true
+  mkdir -p release-artifacts
+  cp target/myapp-1.0.0.jar release-artifacts/
+
+  run_generate_sbom "maven" "source,build,analyzed-artifact" "1.0.0" "myapp" "."
+
+  assert_success
+  assert_output --partial "No Maven Build SBOM"
+  assert_output --partial "Generating Source layer"
+  assert_output --partial "Generating Artifact layer"
+}
+
+# =============================================================================
 # Artifact Layer Tests
 # =============================================================================
 

--- a/tests/sbom/generate-sbom.bats
+++ b/tests/sbom/generate-sbom.bats
@@ -183,6 +183,17 @@ EOF
   assert_output --partial "Generating Artifact layer"
 }
 
+@test "generate-sbomgenerates artifact layer for maven JAR without version suffix (finalName)" {
+  create_maven_project false
+  mkdir -p target
+  echo "mock jar" > target/myapp.jar
+
+  run_generate_sbom "maven" "artifact" "1.0.0" "myapp" "."
+
+  assert_success
+  assert_output --partial "Generating Artifact layer"
+}
+
 @test "generate-sbomwarns when no JARs found for maven" {
   create_maven_project false  # No JAR - script fails when no SBOMs generated
 

--- a/tests/sbom/generate-sbom.bats
+++ b/tests/sbom/generate-sbom.bats
@@ -177,7 +177,7 @@ EOF
   mkdir -p release-artifacts
   cp target/myapp-1.0.0.jar release-artifacts/
 
-  run_generate_sbom "maven" "artifact" "1.0.0" "myapp" "."
+  run_generate_sbom "maven" "analyzed-artifact" "1.0.0" "myapp" "."
 
   assert_success
   assert_output --partial "Generating Artifact layer"
@@ -188,7 +188,7 @@ EOF
   mkdir -p target
   echo "mock jar" > target/myapp.jar
 
-  run_generate_sbom "maven" "artifact" "1.0.0" "myapp" "."
+  run_generate_sbom "maven" "analyzed-artifact" "1.0.0" "myapp" "."
 
   assert_success
   assert_output --partial "Generating Artifact layer"
@@ -197,7 +197,7 @@ EOF
 @test "generate-sbomwarns when no JARs found for maven" {
   create_maven_project false  # No JAR - script fails when no SBOMs generated
 
-  run_generate_sbom "maven" "artifact" "1.0.0" "myapp" "."
+  run_generate_sbom "maven" "analyzed-artifact" "1.0.0" "myapp" "."
 
   assert_failure  # Exits 1 when no SBOMs generated
   assert_output --partial "No JAR files found"
@@ -208,7 +208,7 @@ EOF
   create_npm_project
   echo "mock tarball" > myapp-1.0.0.tgz
 
-  run_generate_sbom "npm" "artifact" "1.0.0" "myapp" "."
+  run_generate_sbom "npm" "analyzed-artifact" "1.0.0" "myapp" "."
 
   assert_success
   assert_output --partial "Generating Artifact layer"
@@ -217,7 +217,7 @@ EOF
 @test "generate-sbomgenerates artifact layer for gradle" {
   create_gradle_project true
 
-  run_generate_sbom "gradle" "artifact" "1.0.0" "myapp" "."
+  run_generate_sbom "gradle" "analyzed-artifact" "1.0.0" "myapp" "."
 
   assert_success
   assert_output --partial "Generating Artifact layer"
@@ -228,7 +228,7 @@ EOF
 # =============================================================================
 
 @test "generate-sbomgenerates container layer when image provided" {
-  run_generate_sbom "maven" "containerimage" "1.0.0" "myapp" "." "ghcr.io/org/myapp:1.0.0"
+  run_generate_sbom "maven" "analyzed-container" "1.0.0" "myapp" "." "ghcr.io/org/myapp:1.0.0"
 
   assert_success
   assert_output --partial "Generating Container layer"
@@ -236,7 +236,7 @@ EOF
 }
 
 @test "generate-sbomskips container layer when no image provided" {
-  run_generate_sbom "maven" "containerimage" "1.0.0" "myapp" "." ""
+  run_generate_sbom "maven" "analyzed-container" "1.0.0" "myapp" "." ""
 
   assert_failure  # Exits 1 when no SBOMs generated
   assert_output --partial "No container image specified"
@@ -250,7 +250,7 @@ EOF
 @test "generate-sbomhandles comma-separated layers" {
   create_maven_project
 
-  run_generate_sbom "maven" "source,artifact" "1.0.0" "myapp" "."
+  run_generate_sbom "maven" "source,analyzed-artifact" "1.0.0" "myapp" "."
 
   assert_success
   assert_output --partial "Generating Source layer"
@@ -262,7 +262,7 @@ EOF
   mkdir -p release-artifacts
   cp target/myapp-1.0.0.jar release-artifacts/
 
-  run_generate_sbom "maven" "source,artifact,containerimage" "1.0.0" "myapp" "." "ghcr.io/org/myapp:1.0.0"
+  run_generate_sbom "maven" "source,analyzed-artifact,analyzed-container" "1.0.0" "myapp" "." "ghcr.io/org/myapp:1.0.0"
 
   assert_success
   assert_output --partial "Generating Source layer"


### PR DESCRIPTION
# Pull Request Description

Splitted the PR https://github.com/diggsweden/reusable-ci/pull/98 from into three commits:

1. fix: jar SBOM missing — The JAR search only matched myapp-1.0.0.jar. Spring Boot projects often strip the version (myapp.jar), both patterns are matched.
  2. refactor: CISA layer names — artifact becomes analyzed-artifact, containerimage becomes analyzed-container, matching the CISA SBOM Types
  3. feat: build SBOM layer — Runs the CycloneDX Maven plugin during build to capture the actual resolved dependency tree, not just what Syft does.

  ---
What was added to the original PR during split and review
  
A missing bom.json now warns and continues, so source and artefact layers still get produced. (return 0)
Added the $MAVEN_CLI_OPTS (noisy output, no batch mode),
Added  continue-on-error (plugin failure does not matter), 
Added renovate annotation (version goes stale)
Added documentation about CISA types
Added edge test case



## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
