### PR TITLE
fix: reset working tree after install to prevent false lint failures

### DIFF
--- a/.github/workflows/lint-devbase.yml
+++ b/.github/workflows/lint-devbase.yml
@@ -95,6 +95,11 @@ jobs:
         run: |
           mise trust
           just install
+      - name: Reset install-time working tree changes
+        # Install hooks (e.g. npm prepare) can modify tracked files like
+        # package-lock.json, causing false positives in lint-version-control.
+        # Reset so linters only see actual committed source state.
+        run: git checkout -- .
       - name: Run linting
         run: |
           run_available_lint_recipe() {


### PR DESCRIPTION
Install hooks (e.g. npm prepare) can modify tracked files like package-lock.json, causing false positives in lint-version-control.


## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
