### PR TITLE
feat: add OpenGrep SAST support to reusable CI

### DIFF
--- a/.github/workflows/build-gradle-android.yml
+++ b/.github/workflows/build-gradle-android.yml
@@ -124,12 +124,17 @@ jobs:
           sparse-checkout: scripts
       - name: Generate artifact names
         id: artifact-names
+        env:
+          INCLUDE_DATE_STAMP: ${{ inputs['include-date-stamp'] }}
+          ARTIFACT_NAME_PREFIX: ${{ inputs['artifact-name-prefix'] }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+          PRODUCT_FLAVOR: ${{ inputs['product-flavor'] }}
         run: |
           bash .github-shared/scripts/android/generate-artifact-names.sh \
-            "${{ inputs['include-date-stamp'] }}" \
-            "${{ inputs['artifact-name-prefix'] }}" \
-            "${{ github.event.repository.name }}" \
-            "${{ inputs['product-flavor'] }}" >> "$GITHUB_OUTPUT"
+            "$INCLUDE_DATE_STAMP" \
+            "$ARTIFACT_NAME_PREFIX" \
+            "$REPOSITORY_NAME" \
+            "$PRODUCT_FLAVOR" >> "$GITHUB_OUTPUT"
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -154,12 +159,17 @@ jobs:
         run: bash .github-shared/scripts/android/get-version-info.sh >> "$GITHUB_OUTPUT"
       - name: Determine build tasks
         id: build-tasks
+        env:
+          PRODUCT_FLAVOR: ${{ inputs['product-flavor'] }}
+          BUILD_TYPES: ${{ inputs['build-types'] }}
+          INCLUDE_AAB: ${{ inputs['include-aab'] }}
+          BUILD_MODULE: ${{ inputs['build-module'] }}
         run: |
           bash .github-shared/scripts/android/resolve-build-tasks.sh \
-            "${{ inputs['product-flavor'] }}" \
-            "${{ inputs['build-types'] }}" \
-            "${{ inputs['include-aab'] }}" \
-            "${{ inputs['build-module'] }}" >> "$GITHUB_OUTPUT"
+            "$PRODUCT_FLAVOR" \
+            "$BUILD_TYPES" \
+            "$INCLUDE_AAB" \
+            "$BUILD_MODULE" >> "$GITHUB_OUTPUT"
       - name: Run Gradle build
         working-directory: ${{ inputs['working-directory'] }}
         env:

--- a/.github/workflows/build-gradle-app.yml
+++ b/.github/workflows/build-gradle-app.yml
@@ -145,18 +145,24 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          GRADLE_TASKS: ${{ inputs['gradle-tasks'] }}
+          SKIP_TESTS: ${{ inputs['skip-tests'] }}
         run: |
-          printf "Running Gradle tasks: %s\n" "${{ inputs['gradle-tasks'] }}"
-          if [ "${{ inputs['skip-tests'] }}" = "true" ]; then
-            ./gradlew ${{ inputs['gradle-tasks'] }} -x test
+          printf "Running Gradle tasks: %s\n" "$GRADLE_TASKS"
+          # shellcheck disable=SC2086
+          if [ "$SKIP_TESTS" = "true" ]; then
+            ./gradlew $GRADLE_TASKS -x test
           else
-            ./gradlew ${{ inputs['gradle-tasks'] }}
+            # shellcheck disable=SC2086
+            ./gradlew $GRADLE_TASKS
           fi
       - name: List built artifacts
         working-directory: ${{ inputs['working-directory'] }}
+        env:
+          BUILD_MODULE: ${{ inputs['build-module'] }}
         run: |
           printf "Built artifacts:\n"
-          find ${{ inputs['build-module'] }}/build/outputs -type f \( -name "*.apk" -o -name "*.aab" -o -name "*.jar" \) -ls || printf "No artifacts found\n"
+          find "$BUILD_MODULE"/build/outputs -type f \( -name "*.apk" -o -name "*.aab" -o -name "*.jar" \) -ls || printf "No artifacts found\n"
       - name: Upload Gradle artifacts
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:

--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -97,10 +97,12 @@ jobs:
       - name: Build application
         if: ${{ inputs['build-type'] == 'app' }}
         working-directory: ${{ inputs['working-directory'] }}
+        env:
+          SKIP_TESTS: ${{ inputs['skip-tests'] }}
         run: |
           printf "Building Maven application...\n"
           # shellcheck disable=SC2086
-          if [ "${{ inputs['skip-tests'] }}" = "true" ]; then
+          if [ "$SKIP_TESTS" = "true" ]; then
             mvn $MAVEN_CLI_OPTS clean package -DskipTests
           else
             mvn $MAVEN_CLI_OPTS clean package

--- a/.github/workflows/build-xcode-ios.yml
+++ b/.github/workflows/build-xcode-ios.yml
@@ -150,15 +150,20 @@ jobs:
 
       - name: Generate artifact names
         id: artifact-names
+        env:
+          ARTIFACT_NAME: ${{ inputs['artifact-name'] }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+          INCLUDE_TAG: ${{ inputs['include-tag'] }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ -n "${{ inputs['artifact-name'] }}" ]; then
-            BASE_NAME="${{ inputs['artifact-name'] }}"
+          if [ -n "$ARTIFACT_NAME" ]; then
+            BASE_NAME="$ARTIFACT_NAME"
           else
-            BASE_NAME="${{ github.event.repository.name }}"
+            BASE_NAME="$REPOSITORY_NAME"
           fi
 
-          if [ "${{ inputs['include-tag'] }}" = "true" ]; then
-            IPA_NAME="${BASE_NAME}-${{ github.ref_name }}"
+          if [ "$INCLUDE_TAG" = "true" ]; then
+            IPA_NAME="${BASE_NAME}-$REF_NAME"
           else
             IPA_NAME="${BASE_NAME}"
           fi
@@ -167,8 +172,10 @@ jobs:
           printf "IPA artifact: %s\n" "${IPA_NAME}"
 
       - name: Select Xcode version
+        env:
+          XCODE_VERSION: ${{ inputs.xcode-version }}
         run: |
-          sudo xcode-select -s /Applications/Xcode_${{ inputs.xcode-version }}.app
+          sudo xcode-select -s "/Applications/Xcode_${XCODE_VERSION}.app"
           xcodebuild -version
 
       - name: Install build dependencies
@@ -181,12 +188,14 @@ jobs:
       - name: Generate Xcode project with XcodeGen
         if: ${{ inputs['use-xcodegen'] }}
         working-directory: ${{ inputs['working-directory'] }}
+        env:
+          XCODEGEN_SPEC: ${{ inputs['xcodegen-spec'] }}
         run: |
           if ! command -v xcodegen &> /dev/null; then
             brew install xcodegen
           fi
-          xcodegen generate --spec "${{ inputs['xcodegen-spec'] }}"
-          printf "✓ Xcode project generated from %s\n" "${{ inputs['xcodegen-spec'] }}"
+          xcodegen generate --spec "$XCODEGEN_SPEC"
+          printf "✓ Xcode project generated from %s\n" "$XCODEGEN_SPEC"
 
       - name: Setup code signing
         if: ${{ inputs['enable-code-signing'] }}
@@ -200,10 +209,13 @@ jobs:
       - name: Get version info
         id: version-info
         working-directory: ${{ inputs['working-directory'] }}
+        env:
+          PROJECT_PATH_INPUT: ${{ inputs.project }}
+          WORKSPACE_PATH_INPUT: ${{ inputs.workspace }}
         run: |
           bash .github-shared/scripts/apple/get-version-info.sh \
-            "${{ inputs.project }}" \
-            "${{ inputs.workspace }}" >> "$GITHUB_OUTPUT"
+            "$PROJECT_PATH_INPUT" \
+            "$WORKSPACE_PATH_INPUT" >> "$GITHUB_OUTPUT"
 
       - name: Setup xcconfig from secret
         id: setup-xcconfig

--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -44,6 +44,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }} # https://github.com/actions/checkout/issues/426
       - name: Determine base branch
         id: base
+        env:
+          INPUT_BASE_BRANCH: ${{ inputs.base-branch }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.base_ref }}
         run: |
           set_base_branch() {
             local branch="$1"
@@ -54,17 +58,19 @@ jobs:
           }
 
           # If explicitly provided, use it
-          if [ -n "${{ inputs.base-branch }}" ]; then
-            set_base_branch "${{ inputs.base-branch }}" "Using explicitly provided base: ${{ inputs.base-branch }}"
+          if [ -n "$INPUT_BASE_BRANCH" ]; then
+            set_base_branch "$INPUT_BASE_BRANCH" "Using explicitly provided base: $INPUT_BASE_BRANCH"
           # For PRs, use the PR target branch
-          elif [ "${{ github.event_name }}" = "pull_request" ] && [ -n "${{ github.base_ref }}" ]; then
-            set_base_branch "${{ github.base_ref }}" "Auto-detected PR base: ${{ github.base_ref }}"
+          elif [ "$EVENT_NAME" = "pull_request" ] && [ -n "$PR_BASE_REF" ]; then
+            set_base_branch "$PR_BASE_REF" "Auto-detected PR base: $PR_BASE_REF"
           # Fallback to main
           else
             set_base_branch "main" "Using default base: main"
           fi
       - name: Setup base branch
-        run: git fetch origin ${{ steps.base.outputs.branch }}:${{ steps.base.outputs.branch }}
+        env:
+          BASE_BRANCH: ${{ steps.base.outputs.branch }}
+        run: git fetch origin "$BASE_BRANCH:$BASE_BRANCH"
       - name: Install gommitlint
         env:
           # renovate: datasource=gitea-releases depName=itiquette/gommitlint registryUrl=https://codeberg.org

--- a/.github/workflows/lint-swift.yml
+++ b/.github/workflows/lint-swift.yml
@@ -82,9 +82,11 @@ jobs:
           fetch-depth: 1
 
       - name: Install swift-format
+        env:
+          SWIFT_FORMAT_VERSION: ${{ inputs['swift-format-version'] }}
         run: |
-          if [ -n "${{ inputs['swift-format-version'] }}" ]; then
-            brew install swift-format@${{ inputs['swift-format-version'] }}
+          if [ -n "$SWIFT_FORMAT_VERSION" ]; then
+            brew install "swift-format@$SWIFT_FORMAT_VERSION"
           else
             brew install swift-format
           fi
@@ -93,12 +95,14 @@ jobs:
       - name: Find Swift files
         id: find-files
         working-directory: ${{ inputs['working-directory'] }}
+        env:
+          FILE_PATTERN: ${{ inputs['file-pattern'] }}
         run: |
-          FILE_COUNT=$(git ls-files '${{ inputs['file-pattern'] }}' | wc -l | tr -d ' ')
+          FILE_COUNT=$(git ls-files -- "$FILE_PATTERN" | wc -l | tr -d ' ')
 
           if [ "$FILE_COUNT" -eq 0 ]; then
             printf "found=false\n" >> "$GITHUB_OUTPUT"
-            printf "No Swift files found matching pattern: %s\n" "${{ inputs['file-pattern'] }}"
+            printf "No Swift files found matching pattern: %s\n" "$FILE_PATTERN"
             exit 0
           fi
 
@@ -109,11 +113,13 @@ jobs:
       - name: Run swift-format lint
         if: steps.find-files.outputs.found == 'true'
         working-directory: ${{ inputs['working-directory'] }}
+        env:
+          FILE_PATTERN: ${{ inputs['file-pattern'] }}
         run: |
           set +e
 
           # Get list of Swift files
-          SWIFT_FILES=$(git ls-files '${{ inputs['file-pattern'] }}')
+          SWIFT_FILES=$(git ls-files -- "$FILE_PATTERN")
           FILE_COUNT=$(printf "%s" "$SWIFT_FILES" | wc -l | tr -d ' ')
 
           printf "Running swift-format on %s files...\n" "${FILE_COUNT}"
@@ -163,12 +169,15 @@ jobs:
 
       - name: Run SwiftLint
         working-directory: ${{ inputs['working-directory'] }}
+        env:
+          SWIFTLINT_CONFIG_PATH: ${{ inputs['swiftlint-config'] }}
+          FAIL_ON_WARNING: ${{ inputs['fail-on-warning'] }}
         run: |
           set +e
 
-          if [ -f "${{ inputs['swiftlint-config'] }}" ]; then
-            printf "Using SwiftLint configuration: %s\n" "${{ inputs['swiftlint-config'] }}"
-            swiftlint lint --config "${{ inputs['swiftlint-config'] }}" --reporter github-actions-logging > swiftlint-output.txt 2>&1
+          if [ -f "$SWIFTLINT_CONFIG_PATH" ]; then
+            printf "Using SwiftLint configuration: %s\n" "$SWIFTLINT_CONFIG_PATH"
+            swiftlint lint --config "$SWIFTLINT_CONFIG_PATH" --reporter github-actions-logging > swiftlint-output.txt 2>&1
           else
             printf "No SwiftLint configuration found, using defaults\n"
             swiftlint lint --reporter github-actions-logging > swiftlint-output.txt 2>&1
@@ -179,7 +188,7 @@ jobs:
           cat swiftlint-output.txt
 
           if [ $SWIFTLINT_EXIT_CODE -ne 0 ]; then
-            if [ "${{ inputs['fail-on-warning'] }}" = "true" ]; then
+            if [ "$FAIL_ON_WARNING" = "true" ]; then
               printf "::error::SwiftLint found issues\n"
               {
                 printf "## SwiftLint Issues 🔴\n"
@@ -215,6 +224,11 @@ jobs:
     if: always()
     steps:
       - name: Check results
+        env:
+          ENABLE_SWIFTFORMAT: ${{ inputs['enable-swiftformat'] }}
+          SWIFTFORMAT_RESULT: ${{ needs.swift-format-lint.result }}
+          ENABLE_SWIFTLINT: ${{ inputs['enable-swiftlint'] }}
+          SWIFTLINT_RESULT: ${{ needs.swiftlint.result }}
         run: |
           {
             printf "## Swift Linting Summary\n"
@@ -222,10 +236,10 @@ jobs:
             printf "| Linter | Status |\n"
             printf "|--------|--------|\n"
 
-            if [ "${{ inputs['enable-swiftformat'] }}" = "true" ]; then
-              if [ "${{ needs.swift-format-lint.result }}" = "success" ]; then
+            if [ "$ENABLE_SWIFTFORMAT" = "true" ]; then
+              if [ "$SWIFTFORMAT_RESULT" = "success" ]; then
                 printf "| swift-format | ✓ Pass |\n"
-              elif [ "${{ needs.swift-format-lint.result }}" = "skipped" ]; then
+              elif [ "$SWIFTFORMAT_RESULT" = "skipped" ]; then
                 printf "| swift-format | − Skipped |\n"
               else
                 printf "| swift-format | ✗ Fail |\n"
@@ -234,10 +248,10 @@ jobs:
               printf "| swift-format | 🔸 Disabled |\n"
             fi
 
-            if [ "${{ inputs['enable-swiftlint'] }}" = "true" ]; then
-              if [ "${{ needs.swiftlint.result }}" = "success" ]; then
+            if [ "$ENABLE_SWIFTLINT" = "true" ]; then
+              if [ "$SWIFTLINT_RESULT" = "success" ]; then
                 printf "| SwiftLint | ✓ Pass |\n"
-              elif [ "${{ needs.swiftlint.result }}" = "skipped" ]; then
+              elif [ "$SWIFTLINT_RESULT" = "skipped" ]; then
                 printf "| SwiftLint | − Skipped |\n"
               else
                 printf "| SwiftLint | ✗ Fail |\n"
@@ -246,15 +260,15 @@ jobs:
               printf "| SwiftLint | 🔸 Disabled |\n"
             fi
 
-            if { [ "${{ inputs['enable-swiftformat'] }}" = "true" ] && [ "${{ needs.swift-format-lint.result }}" = "failure" ]; } || \
-               { [ "${{ inputs['enable-swiftlint'] }}" = "true" ] && [ "${{ needs.swiftlint.result }}" = "failure" ]; }; then
+            if { [ "$ENABLE_SWIFTFORMAT" = "true" ] && [ "$SWIFTFORMAT_RESULT" = "failure" ]; } || \
+               { [ "$ENABLE_SWIFTLINT" = "true" ] && [ "$SWIFTLINT_RESULT" = "failure" ]; }; then
               printf "\n"
               printf "### ✗ Linting failed\n"
               printf "Please fix the issues above.\n"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if { [ "${{ inputs['enable-swiftformat'] }}" = "true" ] && [ "${{ needs.swift-format-lint.result }}" = "failure" ]; } || \
-             { [ "${{ inputs['enable-swiftlint'] }}" = "true" ] && [ "${{ needs.swiftlint.result }}" = "failure" ]; }; then
+          if { [ "$ENABLE_SWIFTFORMAT" = "true" ] && [ "$SWIFTFORMAT_RESULT" = "failure" ]; } || \
+             { [ "$ENABLE_SWIFTLINT" = "true" ] && [ "$SWIFTLINT_RESULT" = "failure" ]; }; then
             exit 1
           fi

--- a/.github/workflows/publish-apple-appstore.yml
+++ b/.github/workflows/publish-apple-appstore.yml
@@ -150,13 +150,15 @@ jobs:
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          IPA_FILE: ${{ steps.find-ipa.outputs.ipa-file }}
+          PLATFORM: ${{ inputs.platform }}
         run: |
           printf "Validating IPA...\n"
 
           xcrun altool \
             --validate-app \
-            --file "${{ steps.find-ipa.outputs.ipa-file }}" \
-            --type ${{ inputs.platform }} \
+            --file "$IPA_FILE" \
+            --type "$PLATFORM" \
             --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
             --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID" \
             --output-format json
@@ -167,6 +169,8 @@ jobs:
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          IPA_FILE: ${{ steps.find-ipa.outputs.ipa-file }}
+          PLATFORM: ${{ inputs.platform }}
         run: |
           set -eo pipefail
 
@@ -175,8 +179,8 @@ jobs:
           xcrun altool \
             --output-format json \
             --upload-app \
-            --file "${{ steps.find-ipa.outputs.ipa-file }}" \
-            --type ${{ inputs.platform }} \
+            --file "$IPA_FILE" \
+            --type "$PLATFORM" \
             --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
             --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID" \
           | tee upload-result.json

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -228,7 +228,10 @@ jobs:
         run: bash .github-shared/scripts/container/extract-npm-tarball.sh
       - name: Verify NPM artifacts
         if: *if_has_npm_artifacts
-        run: bash .github-shared/scripts/container/validate-artifacts.sh npm dist "${{ inputs.context }}/${{ inputs['container-file'] }}"
+        env:
+          CONTAINER_CONTEXT: ${{ inputs.context }}
+          CONTAINER_FILE: ${{ inputs['container-file'] }}
+        run: bash .github-shared/scripts/container/validate-artifacts.sh npm dist "$CONTAINER_CONTEXT/$CONTAINER_FILE"
       - name: Download Gradle artifacts
         if: &if_has_gradle_artifacts ${{ contains(inputs['artifact-types'], 'gradle') }}
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
@@ -241,7 +244,9 @@ jobs:
         run: bash .github-shared/scripts/container/validate-artifacts.sh gradle build/libs
       - name: Verify Containerfile
         id: containerfile
-        run: bash .github-shared/scripts/container/validate-containerfile.sh "${{ inputs['container-file'] }}"
+        env:
+          CONTAINER_FILE: ${{ inputs['container-file'] }}
+        run: bash .github-shared/scripts/container/validate-containerfile.sh "$CONTAINER_FILE"
       - name: Set up QEMU
         if: contains(inputs.platforms, ',') || contains(inputs.platforms, 'arm')
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
@@ -265,20 +270,30 @@ jobs:
           password: ${{ inputs['use-ci-token'] && secrets.GITHUB_TOKEN || secrets['registry-password'] }}
       - name: Determine Image Name
         id: image-name
+        env:
+          TARGET_REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME_INPUT: ${{ inputs['image-name'] }}
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           bash .github-shared/scripts/container/resolve-image-name.sh \
-            "${{ inputs.registry }}" \
-            "${{ inputs['image-name'] }}" \
-            "${{ github.repository }}" \
-            "${{ github.repository_owner }}" >> "$GITHUB_OUTPUT"
+            "$TARGET_REGISTRY" \
+            "$IMAGE_NAME_INPUT" \
+            "$REPOSITORY" \
+            "$REPOSITORY_OWNER" >> "$GITHUB_OUTPUT"
       - name: Validate Image Namespace
         if: *if_push_image
+        env:
+          IMAGE_NAME: ${{ steps.image-name.outputs.name }}
+          REPOSITORY: ${{ github.repository }}
+          TARGET_REGISTRY: ${{ inputs.registry }}
+          ENFORCE_NAMESPACE: ${{ inputs['enforce-namespace'] || github.repository_owner }}
         run: |
           bash .github-shared/scripts/container/validate-namespace.sh \
-            "${{ steps.image-name.outputs.name }}" \
-            "${{ github.repository }}" \
-            "${{ inputs.registry }}" \
-            "${{ inputs['enforce-namespace'] || github.repository_owner }}"
+            "$IMAGE_NAME" \
+            "$REPOSITORY" \
+            "$TARGET_REGISTRY" \
+            "$ENFORCE_NAMESPACE"
       - name: Extract Image Metadata
         id: metadata
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
@@ -319,9 +334,11 @@ jobs:
           sbom: ${{ inputs['enable-sbom'] }}
       - name: Check SLSA compatibility
         if: ${{ inputs['push-image'] && inputs['enable-slsa'] && inputs.registry != 'ghcr.io' }}
+        env:
+          TARGET_REGISTRY: ${{ inputs.registry }}
         run: |
           printf "::notice::SLSA provenance generation only supports ghcr.io registry\n"
-          printf "::notice::Current registry: %s\n" "${{ inputs.registry }}"
+          printf "::notice::Current registry: %s\n" "$TARGET_REGISTRY"
           printf "::notice::SLSA provenance attestation will be skipped\n"
           printf "::notice::To enable SLSA: Use registry: ghcr.io or set enable-slsa: false\n"
       - name: Export digest

--- a/.github/workflows/publish-dev-container.yml
+++ b/.github/workflows/publish-dev-container.yml
@@ -131,11 +131,14 @@ jobs:
           path: ${{ inputs['working-directory'] }}
       - name: Verify Maven artifacts
         if: ${{ contains(inputs['artifact-types'], 'maven') }}
+        env:
+          WORKING_DIRECTORY: ${{ inputs['working-directory'] }}
+          CONTAINER_FILE: ${{ inputs['container-file'] }}
         run: |
           bash .github-shared/scripts/container/validate-artifacts.sh \
             maven \
-            "${{ inputs['working-directory'] }}/target" \
-            "${{ inputs['working-directory'] }}/${{ inputs['container-file'] }}"
+            "$WORKING_DIRECTORY/target" \
+            "$WORKING_DIRECTORY/$CONTAINER_FILE"
       - name: Download NPM artifacts
         if: ${{ contains(inputs['artifact-types'], 'npm') }}
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
@@ -148,11 +151,14 @@ jobs:
         run: bash "$GITHUB_WORKSPACE/.github-shared/scripts/container/extract-npm-tarball.sh"
       - name: Verify NPM artifacts
         if: ${{ contains(inputs['artifact-types'], 'npm') }}
+        env:
+          WORKING_DIRECTORY: ${{ inputs['working-directory'] }}
+          CONTAINER_FILE: ${{ inputs['container-file'] }}
         run: |
           bash .github-shared/scripts/container/validate-artifacts.sh \
             npm \
-            "${{ inputs['working-directory'] }}/dist" \
-            "${{ inputs['working-directory'] }}/${{ inputs['container-file'] }}"
+            "$WORKING_DIRECTORY/dist" \
+            "$WORKING_DIRECTORY/$CONTAINER_FILE"
       - name: Download Gradle artifacts
         if: ${{ contains(inputs['artifact-types'], 'gradle') }}
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
@@ -161,11 +167,14 @@ jobs:
           path: ${{ inputs['working-directory'] }}
       - name: Verify Gradle artifacts
         if: ${{ contains(inputs['artifact-types'], 'gradle') }}
+        env:
+          WORKING_DIRECTORY: ${{ inputs['working-directory'] }}
+          CONTAINER_FILE: ${{ inputs['container-file'] }}
         run: |
           bash .github-shared/scripts/container/validate-artifacts.sh \
             gradle \
-            "${{ inputs['working-directory'] }}/build/libs" \
-            "${{ inputs['working-directory'] }}/${{ inputs['container-file'] }}"
+            "$WORKING_DIRECTORY/build/libs" \
+            "$WORKING_DIRECTORY/$CONTAINER_FILE"
       - name: Set up Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Check registry authentication configuration
@@ -182,9 +191,12 @@ jobs:
           password: ${{ inputs['use-ci-token'] && secrets.GITHUB_TOKEN || secrets['registry-password'] }}
       - name: Generate dev tags
         id: tags
+        env:
+          TARGET_REGISTRY: ${{ inputs.registry }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           DEV_VERSION=$(bash .github-shared/scripts/version/generate-dev-version.sh)
-          IMAGE_NAME="${{ inputs.registry }}/${{ github.repository }}"
+          IMAGE_NAME="$TARGET_REGISTRY/$REPOSITORY"
 
           printf "tags=%s:%s\n" "${IMAGE_NAME}" "${DEV_VERSION}" >> "$GITHUB_OUTPUT"
           printf "image=%s:%s\n" "${IMAGE_NAME}" "${DEV_VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-dev-npm.yml
+++ b/.github/workflows/publish-dev-npm.yml
@@ -136,16 +136,19 @@ jobs:
       - name: Validate package scope
         if: ${{ inputs.package-scope != '' }}
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_SCOPE: ${{ inputs.package-scope }}
+          TARGET_REGISTRY: ${{ inputs.registry }}
         run: |
           NAME=$(node -p "require('./package.json').name")
-          SCOPE="${{ inputs.package-scope }}"
+          SCOPE="$PACKAGE_SCOPE"
           if [[ "$NAME" != "${SCOPE}"/* ]]; then
             printf "::error::package.json name must be scoped as %s/<pkg>\n" "${SCOPE}"
             printf "Found: %s\n" "$NAME"
             exit 1
           fi
           # Configure scoped registry
-          npm config set "${SCOPE}:registry" "${{ inputs.registry }}"
+          npm config set "${SCOPE}:registry" "$TARGET_REGISTRY"
       - name: Download NPM build artifacts
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
@@ -160,7 +163,9 @@ jobs:
           sparse-checkout: scripts
       - name: Extract tarball contents
         working-directory: ${{ inputs.working-directory }}
-        run: bash "${{ github.workspace }}/.github-shared/scripts/publish/npm-validate-tarball.sh"
+        env:
+          GITHUB_WORKSPACE_PATH: ${{ github.workspace }}
+        run: bash "$GITHUB_WORKSPACE_PATH/.github-shared/scripts/publish/npm-validate-tarball.sh"
       - name: Check registry authentication configuration
         env:
           USE_CI_TOKEN: ${{ inputs['use-ci-token'] }}
@@ -180,10 +185,11 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         env:
           NODE_AUTH_TOKEN: ${{ inputs['use-ci-token'] && secrets.GITHUB_TOKEN || secrets['registry-password'] }}
+          DEV_VERSION: ${{ steps.tags.outputs.dev_version }}
+          TARGET_REGISTRY: ${{ inputs.registry }}
         run: |
           PKG_NAME=$(node -p "require('./package.json').name")
-          DEV_VERSION="${{ steps.tags.outputs.dev_version }}"
-          if npm view "${PKG_NAME}@${DEV_VERSION}" version --registry "${{ inputs.registry }}" 2>/dev/null; then
+          if npm view "${PKG_NAME}@${DEV_VERSION}" version --registry "$TARGET_REGISTRY" 2>/dev/null; then
             printf "::warning::Package %s@%s already exists in registry — skipping publish (same commit SHA)\n" \
               "${PKG_NAME}" "${DEV_VERSION}"
             printf "already_published=true\n" >> "$GITHUB_OUTPUT"
@@ -220,9 +226,10 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         env:
           NODE_AUTH_TOKEN: ${{ inputs['use-ci-token'] && secrets.GITHUB_TOKEN || secrets['registry-password'] }}
+          TARGET_REGISTRY: ${{ inputs.registry }}
         run: |
           PKG_NAME=$(node -p "require('./package.json').name")
           PKG_VERSION=$(node -p "require('./package.json').version")
-          printf "Publishing %s@%s to %s with tag 'dev'\n" "${PKG_NAME}" "${PKG_VERSION}" "${{ inputs.registry }}"
+          printf "Publishing %s@%s to %s with tag 'dev'\n" "${PKG_NAME}" "${PKG_VERSION}" "$TARGET_REGISTRY"
           npm publish --tag dev
           printf "✅ Published successfully\n"

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -122,12 +122,13 @@ jobs:
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVENCENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVENCENTRAL_PASSWORD }}
+          SETTINGS_PATH: ${{ inputs['settings-path'] }}
+          MAVEN_PROFILE: ${{ inputs.profile }}
         run: |
           printf "Deploying to Maven Central...\n"
 
           # Use settings file if provided
           SETTINGS_ARG=""
-          SETTINGS_PATH="${{ inputs['settings-path'] }}"
           if [ -n "${SETTINGS_PATH}" ]; then
             if [ -f "${SETTINGS_PATH}" ]; then
               SETTINGS_ARG="--settings ${SETTINGS_PATH}"
@@ -140,11 +141,14 @@ jobs:
 
           # Deploy with profile (includes GPG signing via maven-gpg-plugin)
           # shellcheck disable=SC2086
-          mvn $MAVEN_CLI_OPTS deploy $SETTINGS_ARG -P${{ inputs.profile }} -DskipTests
+          mvn $MAVEN_CLI_OPTS deploy $SETTINGS_ARG -P"$MAVEN_PROFILE" -DskipTests
       - name: Generate publish summary
+        env:
+          IS_SNAPSHOT: ${{ steps.version-info.outputs.IS_SNAPSHOT }}
+          VERSION: ${{ steps.version-info.outputs.VERSION }}
         run: |
           print_release_type() {
-            if [ "${{ steps.version-info.outputs.IS_SNAPSHOT }}" = "true" ]; then
+            if [ "$IS_SNAPSHOT" = "true" ]; then
               printf "%s **Type:** %s\n" "-" "SNAPSHOT"
             else
               printf "%s **Type:** %s\n" "-" "Release"
@@ -152,7 +156,7 @@ jobs:
           }
 
           print_release_notice() {
-            if [ "${{ steps.version-info.outputs.IS_SNAPSHOT }}" = "true" ]; then
+            if [ "$IS_SNAPSHOT" = "true" ]; then
               printf "⚠️ **SNAPSHOT** releases are available immediately in the snapshot repository.\n"
             else
               printf "✓ **Release** deployed to staging. Will be published to Central within 30 minutes.\n"
@@ -162,7 +166,7 @@ jobs:
           {
             printf "## Published to Maven Central 🚀\n"
             printf "\n"
-            printf "%s **Version:** %s\n" "-" "${{ steps.version-info.outputs.VERSION }}"
+            printf "%s **Version:** %s\n" "-" "$VERSION"
             print_release_type
             printf "%s **Registry:** [Maven Central](https://central.sonatype.com/)\n" "-"
             printf "\n"

--- a/.github/workflows/publish-maven-github.yml
+++ b/.github/workflows/publish-maven-github.yml
@@ -136,26 +136,31 @@ jobs:
         if: ${{ inputs['attach-pattern'] != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ATTACH_PATTERN: ${{ inputs['attach-pattern'] }}
+          REF_NAME: ${{ github.ref_name }}
         working-directory: ${{ inputs['working-directory'] }}
         run: |
-          for file in ${{ inputs['attach-pattern'] }}; do
+          for file in $ATTACH_PATTERN; do
             if [ -f "$file" ]; then
               printf "Uploading %s to release...\n" "$file"
-              gh release upload "${{ github.ref_name }}" "$file" --clobber || printf "::warning::Failed to upload %s\n" "$file"
+              gh release upload "$REF_NAME" "$file" --clobber || printf "::warning::Failed to upload %s\n" "$file"
             fi
           done
       - name: Generate publish summary
+        env:
+          REPOSITORY: ${{ github.repository }}
+          PACKAGE_TYPE: ${{ inputs['package-type'] }}
         run: |
           print_repository_link() {
             local repo
-            repo="${{ github.repository }}"
+            repo="$REPOSITORY"
             printf "%s **Repository:** [%s](https://github.com/%s/packages)\n" "-" "$repo" "$repo"
           }
 
           {
             printf "## Published to GitHub Packages 📦\n"
             printf "\n"
-            printf "%s **Package Type:** %s\n" "-" "${{ inputs['package-type'] }}"
+            printf "%s **Package Type:** %s\n" "-" "$PACKAGE_TYPE"
             printf "%s **Registry:** GitHub Packages\n" "-"
             print_repository_link
             printf "\n"

--- a/.github/workflows/pullrequest-orchestrator.yml
+++ b/.github/workflows/pullrequest-orchestrator.yml
@@ -39,6 +39,8 @@
 #   linters.megalint: MegaLinter with 50+ linters (default: true)
 #   linters.publiccodelint: Publiccode.yml validation (default: false)
 #   linters.devbasecheck: devbase-check linting (default: false) - RECOMMENDED
+# Configurable Security:
+#   security.sast-opengrep: OpenGrep SAST with SARIF/GitLab SAST outputs (default: true, opt out with false)
 name: Orchestrate Pull Request
 on:
   workflow_call:
@@ -94,6 +96,21 @@ on:
         required: false
         default: false
         type: boolean
+      security.sast-opengrep:
+        description: "Enable OpenGrep SAST scanning"
+        required: false
+        default: true
+        type: boolean
+      security.sast-opengrep-rules:
+        description: "OpenGrep rules path, registry pack, or comma-separated list"
+        required: false
+        default: "p/default"
+        type: string
+      security.sast-opengrep-fail-on-severity:
+        description: "Fail OpenGrep on none, low, medium, or high findings"
+        required: false
+        default: "high"
+        type: string
       reusable-ci-ref:
         description: "Ref for reusable-ci helper scripts checkout (defaults to main)"
         required: false
@@ -133,6 +150,9 @@ jobs:
           LINTER_DEVBASECHECK: ${{ inputs['linters.devbasecheck'] }}
           LINTER_SWIFTFORMAT: ${{ inputs['linters.swiftformat'] }}
           LINTER_SWIFTLINT: ${{ inputs['linters.swiftlint'] }}
+          SAST_OPENGREP: ${{ inputs['security.sast-opengrep'] }}
+          SAST_OPENGREP_RULES: ${{ inputs['security.sast-opengrep-rules'] }}
+          SAST_OPENGREP_FAIL_ON_SEVERITY: ${{ inputs['security.sast-opengrep-fail-on-severity'] }}
         run: bash .github-shared/scripts/plan/write-pr-interface.sh
 
   # ===== Stage 1: Quality =====
@@ -164,9 +184,15 @@ jobs:
           ref: ${{ inputs['reusable-ci-ref'] }}
           path: .github-shared
           sparse-checkout: scripts
+      - name: Download quality stage manifests
+        if: always()
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: ci-results-pr-quality
+          path: .ci-results
       - name: Generate PR summary
         env:
           PROJECT_TYPE: ${{ inputs['project-type'] }}
-          QUALITY_STAGE_RESULT_JSON: ${{ needs.execute-quality-stage.outputs.result-json }}
+          QUALITY_STAGE_RESULT_PATH: .ci-results/pr-quality-result.json
           HAS_SARIF_UPLOAD_TOKEN: ${{ secrets.SARIF_UPLOAD_TOKEN != '' }}
         run: bash .github-shared/scripts/summary/write-pr-summary.sh

--- a/.github/workflows/pullrequest-quality-stage.yml
+++ b/.github/workflows/pullrequest-quality-stage.yml
@@ -15,16 +15,6 @@ on:
         required: false
         default: "main"
         type: string
-    outputs:
-      stage-ran:
-        description: PR quality stage ran
-        value: ${{ jobs.summarize-quality-stage.outputs.stage-ran }}
-      stage-result:
-        description: Normalized PR quality stage result
-        value: ${{ jobs.summarize-quality-stage.outputs.stage-result }}
-      result-json:
-        description: PR quality stage result payload
-        value: ${{ jobs.summarize-quality-stage.outputs.result-json }}
 permissions:
   contents: read
 jobs:
@@ -46,6 +36,17 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/security-dependency-review.yml
     with:
+      reusable-ci-ref: ${{ inputs['reusable-ci-ref'] }}
+  sast-opengrep:
+    name: OpenGrep SAST
+    if: ${{ fromJson(inputs['pr-policy-json']).sastopengrep }}
+    permissions:
+      contents: read
+    secrets: inherit
+    uses: ./.github/workflows/security-opengrep.yml
+    with:
+      opengrep-rules: ${{ fromJson(inputs['pr-context-json']).sast_opengrep_rules }}
+      fail-on-severity: ${{ fromJson(inputs['pr-context-json']).sast_opengrep_fail_on_severity }}
       reusable-ci-ref: ${{ inputs['reusable-ci-ref'] }}
   megalint:
     name: MegaLinter
@@ -79,7 +80,7 @@ jobs:
     name: Status
     runs-on: ubuntu-latest
     if: always()
-    needs: [commit-lint, license-lint, dependency-review, megalint, publiccode-lint, devbase-check-lint, swift-lint]
+    needs: [commit-lint, license-lint, dependency-review, sast-opengrep, megalint, publiccode-lint, devbase-check-lint, swift-lint]
     steps:
       - name: Checkout reusable-ci scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -93,6 +94,7 @@ jobs:
           CHECK_COMMITLINT: Commit Lint|${{ fromJson(inputs['pr-policy-json']).commitlint }}|${{ needs.commit-lint.result }}|true
           CHECK_LICENSLINT: License Lint|${{ fromJson(inputs['pr-policy-json']).licenselint }}|${{ needs.license-lint.result }}|true
           CHECK_DEPENDENCYREVIEW: Dependency Review|${{ fromJson(inputs['pr-policy-json']).dependencyreview }}|${{ needs.dependency-review.result }}|false
+          CHECK_SASTOPENGREP: OpenGrep SAST|${{ fromJson(inputs['pr-policy-json']).sastopengrep }}|${{ needs.sast-opengrep.result }}|false
           CHECK_MEGALINT: MegaLinter|${{ fromJson(inputs['pr-policy-json']).megalint }}|${{ needs.megalint.result }}|true
           CHECK_PUBLICCODELINT: Publiccode Lint|${{ fromJson(inputs['pr-policy-json']).publiccodelint }}|${{ needs.publiccode-lint.result }}|true
           CHECK_DEVBASECHECK: Devbase Check|${{ fromJson(inputs['pr-policy-json']).devbasecheck }}|${{ needs.devbase-check-lint.result }}|false
@@ -102,21 +104,18 @@ jobs:
             "$CHECK_COMMITLINT" \
             "$CHECK_LICENSLINT" \
             "$CHECK_DEPENDENCYREVIEW" \
+            "$CHECK_SASTOPENGREP" \
             "$CHECK_MEGALINT" \
             "$CHECK_PUBLICCODELINT" \
             "$CHECK_DEVBASECHECK" \
             "$CHECK_SWIFT"
   summarize-quality-stage:
     name: Summary
-    needs: [commit-lint, license-lint, dependency-review, megalint, publiccode-lint, devbase-check-lint, swift-lint, quality-status]
+    needs: [commit-lint, license-lint, dependency-review, sast-opengrep, megalint, publiccode-lint, devbase-check-lint, swift-lint, quality-status]
     if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    outputs:
-      stage-ran: ${{ steps.summary.outputs.stage-ran }}
-      stage-result: ${{ steps.summary.outputs.stage-result }}
-      result-json: ${{ steps.summary.outputs.result-json }}
     steps:
       - name: Checkout reusable-ci scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -131,6 +130,7 @@ jobs:
           COMMITLINT_ENABLED: ${{ fromJson(inputs['pr-policy-json']).commitlint }}
           LICENSLINT_ENABLED: ${{ fromJson(inputs['pr-policy-json']).licenselint }}
           DEPENDENCYREVIEW_ENABLED: ${{ fromJson(inputs['pr-policy-json']).dependencyreview }}
+          SASTOPENGREP_ENABLED: ${{ fromJson(inputs['pr-policy-json']).sastopengrep }}
           MEGALINT_ENABLED: ${{ fromJson(inputs['pr-policy-json']).megalint }}
           PUBLICCODELINT_ENABLED: ${{ fromJson(inputs['pr-policy-json']).publiccodelint }}
           DEVBASECHECK_ENABLED: ${{ fromJson(inputs['pr-policy-json']).devbasecheck }}
@@ -138,8 +138,18 @@ jobs:
           COMMITLINT_RESULT: ${{ needs.commit-lint.result }}
           LICENSLINT_RESULT: ${{ needs.license-lint.result }}
           DEPENDENCYREVIEW_RESULT: ${{ needs.dependency-review.result }}
+          SASTOPENGREP_RESULT: ${{ needs.sast-opengrep.result }}
           MEGALINT_RESULT: ${{ needs.megalint.result }}
           PUBLICCODELINT_RESULT: ${{ needs.publiccode-lint.result }}
           DEVBASECHECK_RESULT: ${{ needs.devbase-check-lint.result }}
           SWIFT_RESULT: ${{ needs.swift-lint.result }}
         run: bash .github-shared/scripts/summary/write-pr-quality-stage-result.sh
+      - name: Upload quality stage manifests
+        if: always() && hashFiles('.ci-results/*.json') != ''
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: ci-results-pr-quality
+          path: .ci-results/*.json
+          include-hidden-files: true
+          retention-days: 5
+          if-no-files-found: ignore

--- a/.github/workflows/pullrequest-quality-stage.yml
+++ b/.github/workflows/pullrequest-quality-stage.yml
@@ -89,15 +89,23 @@ jobs:
           path: .github-shared
           sparse-checkout: scripts
       - name: Check quality results
+        env:
+          CHECK_COMMITLINT: Commit Lint|${{ fromJson(inputs['pr-policy-json']).commitlint }}|${{ needs.commit-lint.result }}|true
+          CHECK_LICENSLINT: License Lint|${{ fromJson(inputs['pr-policy-json']).licenselint }}|${{ needs.license-lint.result }}|true
+          CHECK_DEPENDENCYREVIEW: Dependency Review|${{ fromJson(inputs['pr-policy-json']).dependencyreview }}|${{ needs.dependency-review.result }}|false
+          CHECK_MEGALINT: MegaLinter|${{ fromJson(inputs['pr-policy-json']).megalint }}|${{ needs.megalint.result }}|true
+          CHECK_PUBLICCODELINT: Publiccode Lint|${{ fromJson(inputs['pr-policy-json']).publiccodelint }}|${{ needs.publiccode-lint.result }}|true
+          CHECK_DEVBASECHECK: Devbase Check|${{ fromJson(inputs['pr-policy-json']).devbasecheck }}|${{ needs.devbase-check-lint.result }}|false
+          CHECK_SWIFT: Swift Lint|${{ fromJson(inputs['pr-policy-json']).swift }}|${{ needs.swift-lint.result }}|false
         run: |
           bash .github-shared/scripts/summary/write-quality-check-status.sh \
-            "Commit Lint|${{ fromJson(inputs['pr-policy-json']).commitlint }}|${{ needs.commit-lint.result }}|true" \
-            "License Lint|${{ fromJson(inputs['pr-policy-json']).licenselint }}|${{ needs.license-lint.result }}|true" \
-            "Dependency Review|${{ fromJson(inputs['pr-policy-json']).dependencyreview }}|${{ needs.dependency-review.result }}|false" \
-            "MegaLinter|${{ fromJson(inputs['pr-policy-json']).megalint }}|${{ needs.megalint.result }}|true" \
-            "Publiccode Lint|${{ fromJson(inputs['pr-policy-json']).publiccodelint }}|${{ needs.publiccode-lint.result }}|true" \
-            "Devbase Check|${{ fromJson(inputs['pr-policy-json']).devbasecheck }}|${{ needs.devbase-check-lint.result }}|false" \
-            "Swift Lint|${{ fromJson(inputs['pr-policy-json']).swift }}|${{ needs.swift-lint.result }}|false"
+            "$CHECK_COMMITLINT" \
+            "$CHECK_LICENSLINT" \
+            "$CHECK_DEPENDENCYREVIEW" \
+            "$CHECK_MEGALINT" \
+            "$CHECK_PUBLICCODELINT" \
+            "$CHECK_DEVBASECHECK" \
+            "$CHECK_SWIFT"
   summarize-quality-stage:
     name: Summary
     needs: [commit-lint, license-lint, dependency-review, megalint, publiccode-lint, devbase-check-lint, swift-lint, quality-status]

--- a/.github/workflows/release-create-github.yml
+++ b/.github/workflows/release-create-github.yml
@@ -165,9 +165,11 @@ jobs:
           sparse-checkout: scripts
       - name: Determine artifact name
         id: artifact-name
+        env:
+          PROJECT_TYPE: ${{ inputs['project-type'] }}
         run: |
           bash .github-shared/scripts/release/resolve-artifact-name.sh \
-            "${{ inputs['project-type'] }}" >> "$GITHUB_OUTPUT"
+            "$PROJECT_TYPE" >> "$GITHUB_OUTPUT"
       # Download build artifacts based on project type
       - name: Download build artifacts
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
@@ -184,14 +186,18 @@ jobs:
         run: bash .github-shared/scripts/release/resolve-release-metadata.sh
       - name: Generate 3-Layer SBOMs
         if: &if_generate_sbom ${{ inputs['generate-sbom'] }}
+        env:
+          PROJECT_TYPE: ${{ inputs['project-type'] }}
+          RELEASE_VERSION_NO_V: ${{ steps.release-metadata.outputs.version-no-v }}
+          PROJECT_NAME: ${{ steps.release-metadata.outputs.project-name }}
         run: |
           # Use SBOM generation script for source, build and analyzed-artifact layers
           # Use CISA taxonomy layer names that work for all project types
           bash .github-shared/scripts/sbom/generate-sbom.sh \
-            ${{ inputs['project-type'] }} \
+            "$PROJECT_TYPE" \
             "source,build,analyzed-artifact" \
-            "${{ steps.release-metadata.outputs.version-no-v }}" \
-            "${{ steps.release-metadata.outputs.project-name }}"
+            "$RELEASE_VERSION_NO_V" \
+            "$PROJECT_NAME"
 
           printf "Layer 3: Container SBOMs will be downloaded from container build job\n"
       - name: Generate checksums

--- a/.github/workflows/security-opengrep.yml
+++ b/.github/workflows/security-opengrep.yml
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+# Description:
+# Runs OpenGrep SAST, emits portable JSON/SARIF/GitLab SAST outputs, and
+# uploads SARIF to GitHub Code Scanning when SARIF_UPLOAD_TOKEN is configured.
+name: Analyze OpenGrep SAST
+on:
+  workflow_call:
+    inputs:
+      opengrep-rules:
+        description: "OpenGrep rules path, registry pack, or comma-separated list"
+        required: false
+        default: "p/default"
+        type: string
+      fail-on-severity:
+        description: "Fail on none, low, medium, or high findings"
+        required: false
+        default: "high"
+        type: string
+      reusable-ci-ref:
+        description: "Ref for reusable-ci helper scripts checkout (defaults to main)"
+        required: false
+        default: "main"
+        type: string
+permissions:
+  contents: read
+jobs:
+  analysis:
+    name: OpenGrep SAST
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Checkout reusable-ci scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: diggsweden/reusable-ci
+          ref: ${{ inputs['reusable-ci-ref'] }}
+          path: .github-shared
+          sparse-checkout: scripts
+      - name: Run OpenGrep SAST
+        env:
+          OPENGREP_CONFIG: ${{ inputs['opengrep-rules'] }}
+          OPENGREP_FAIL_ON_SEVERITY: ${{ inputs['fail-on-severity'] }}
+          HAS_SARIF_UPLOAD_TOKEN: ${{ secrets.SARIF_UPLOAD_TOKEN != '' }}
+        run: bash .github-shared/scripts/security/run-opengrep.sh
+      - name: Enrich OpenGrep SARIF for GitHub
+        if: always() && hashFiles('opengrep-results.sarif') != ''
+        env:
+          SARIF_FILE: opengrep-results.sarif
+        run: bash .github-shared/scripts/security/enrich-github-sarif.sh
+      - name: Archive OpenGrep outputs
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: opengrep-results
+          path: |
+            opengrep-results.json
+            opengrep-results.txt
+            opengrep-results.sarif
+            opengrep-results.gitlab-sast.json
+          retention-days: 5
+          if-no-files-found: ignore
+      - name: Save OpenGrep SARIF artifact
+        if: always() && hashFiles('opengrep-results.sarif') != ''
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: sarif-opengrep
+          path: opengrep-results.sarif
+          retention-days: 5
+          if-no-files-found: ignore
+      - name: Upload OpenGrep results to Code Scanning
+        if: always() && hashFiles('opengrep-results.sarif') != ''
+        env:
+          SARIF_UPLOAD_TOKEN: ${{ secrets.SARIF_UPLOAD_TOKEN }}
+          SARIF_FILE: opengrep-results.sarif
+          SARIF_CATEGORY: opengrep-sast
+        run: bash .github-shared/scripts/security/upload-sarif.sh

--- a/.github/workflows/validate-release-prerequisites.yml
+++ b/.github/workflows/validate-release-prerequisites.yml
@@ -142,10 +142,15 @@ jobs:
         run: bash .github-shared/scripts/validate/tag-signature.sh "${{ github.ref_name }}" "${{ github.repository }}" "$OSPO_BOT_GPG_PUB"
       - name: Validate Tag Uniqueness
         if: ${{ github.ref_type == 'tag' }}
-        run: bash .github-shared/scripts/validate/tag-uniqueness.sh "${{ github.ref_name }}"
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: bash .github-shared/scripts/validate/tag-uniqueness.sh "$TAG_NAME"
       - name: Validate Tag Commit Availability
         if: ${{ github.ref_type == 'tag' }}
-        run: bash .github-shared/scripts/validate/tag-commit.sh "${{ github.ref_name }}" "${{ inputs.branch }}"
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+          TARGET_BRANCH: ${{ inputs.branch }}
+        run: bash .github-shared/scripts/validate/tag-commit.sh "$TAG_NAME" "$TARGET_BRANCH"
       # ============================================================================
       # SECTION 2: Authorization Validation
       # Checks if user is authorized for non-SNAPSHOT releases

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -167,8 +167,10 @@ jobs:
           git_config_global: true
       - name: Set project type
         id: project-type
+        env:
+          PROJECT_TYPE_INPUT: ${{ inputs['project-type'] }}
         run: |
-          PROJECT_TYPE="${{ inputs['project-type'] }}"
+          PROJECT_TYPE="$PROJECT_TYPE_INPUT"
           echo "Project type: ${PROJECT_TYPE}"
           echo "type=${PROJECT_TYPE}" >> "$GITHUB_OUTPUT"
       - name: Set up JDK for Maven
@@ -184,11 +186,12 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_CLI_OPTS: "--batch-mode --no-transfer-progress --errors --fail-at-end -Dstyle.color=always"
+          WORKING_DIRECTORY_INPUT: ${{ inputs['working-directory'] }}
         run: |
           bash .github-shared/scripts/version/bump-version.sh \
             maven \
             "${GITHUB_REF_NAME#v}" \
-            "${{ inputs['working-directory'] }}"
+            "$WORKING_DIRECTORY_INPUT"
       - name: Setup Java again with cache after version update
         if: *if_maven_project
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -219,11 +222,13 @@ jobs:
       - name: Update NPM version
         if: *if_npm_project
         working-directory: ${{ inputs['working-directory'] }}
+        env:
+          WORKING_DIRECTORY_INPUT: ${{ inputs['working-directory'] }}
         run: |
           bash .github-shared/scripts/version/bump-version.sh \
             npm \
             "${GITHUB_REF_NAME#v}" \
-            "${{ inputs['working-directory'] }}"
+            "$WORKING_DIRECTORY_INPUT"
 
           echo "Pre-installing dependencies..."
           npm ci --ignore-scripts || npm install --ignore-scripts || true
@@ -242,24 +247,29 @@ jobs:
           cache: 'gradle'
       - name: Update Gradle version
         if: *if_gradle_project
+        env:
+          PROJECT_TYPE_OUTPUT: ${{ steps.project-type.outputs.type }}
+          WORKING_DIRECTORY_INPUT: ${{ inputs['working-directory'] }}
+          GRADLE_VERSION_FILE_INPUT: ${{ inputs['gradle-version-file'] }}
         run: |
           echo "::group::Update Gradle version"
           bash .github-shared/scripts/version/bump-version.sh \
-            ${{ steps.project-type.outputs.type }} \
+            "$PROJECT_TYPE_OUTPUT" \
             "${GITHUB_REF_NAME#v}" \
-            "${{ inputs['working-directory'] }}" \
-            "${{ inputs['gradle-version-file'] }}"
+            "$WORKING_DIRECTORY_INPUT" \
+            "$GRADLE_VERSION_FILE_INPUT"
           echo "::endgroup::"
       - name: Update Xcode version
         if: ${{ steps.project-type.outputs.type == 'xcode-ios' }}
         env:
           XCODE_VERSION_FILE: ${{ inputs['xcode-version-file'] }}
+          WORKING_DIRECTORY_INPUT: ${{ inputs['working-directory'] }}
         run: |
           echo "::group::Update Xcode version"
           bash .github-shared/scripts/version/bump-version.sh \
             xcode-ios \
             "${GITHUB_REF_NAME#v}" \
-            "${{ inputs['working-directory'] }}"
+            "$WORKING_DIRECTORY_INPUT"
           echo "::endgroup::"
       - name: Download Full Changelog
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0

--- a/README.md
+++ b/README.md
@@ -142,20 +142,23 @@ jobs:
         permissions:
           contents: read
           packages: read
-        secrets: inherit
+        secrets: inherit  # Pass SARIF_UPLOAD_TOKEN if you want Security / Code Scanning upload
         with:
           reusable-ci-ref: v2.7.0
           project-type: maven  # or npm, gradle, gradle-android, xcode-ios
           # Recommended: Use devbase-check (lightweight, just+mise-based)
-          linters.devbasecheck: true
-          linters.commitlint: false
-          linters.licenselint: false
-          linters.megalint: false
-          # Optional linters:
-          # linters.dependencyreview: true  # Dependency vulnerability scan
-          # linters.publiccodelint: false   # publiccode.yml validation
-          # linters.swiftlint: false        # Swift linting for iOS/macOS
-   ```
+           linters.devbasecheck: true
+           linters.commitlint: false
+           linters.licenselint: false
+           linters.megalint: false
+           # Optional linters:
+           # linters.dependencyreview: true  # Dependency vulnerability scan
+           # security.sast-opengrep: false   # Opt out of OpenGrep SAST
+           # security.sast-opengrep-rules: p/default
+           # security.sast-opengrep-fail-on-severity: high
+           # linters.publiccodelint: false   # publiccode.yml validation
+           # linters.swiftlint: false        # Swift linting for iOS/macOS
+    ```
 
 3. **Create release workflow** - Trigger builds on tags:
    ```yaml

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,10 +1,19 @@
 ## Available Components
 
-This document describes individual workflow components that can be used standalone or combined with orchestrators.
+This document describes reusable workflow components and how they relate to the supported orchestrator entrypoints.
+
+**Recommended stable GitHub entrypoints:**
+- `pullrequest-orchestrator.yml`
+- `release-orchestrator.yml`
+- `release-dev-orchestrator.yml`
+
+Leaf helper workflows such as `build-*`, `publish-*`, `lint-*`, `security-*`, `validate-*`, and selected release helpers can still be used directly by advanced consumers and are suitable for repo-local custom orchestration.
+
+Stage workflows such as `pullrequest-quality-stage.yml`, `release-prepare-stage.yml`, `release-build-stage.yml`, `release-publish-stage.yml`, `release-dev-build-stage.yml`, and `release-dev-publish-stage.yml` are internal composition helpers. Advanced consumers may still use them, but they should be treated as less stable direct-use contracts than the orchestrators and leaf helpers.
 
 **When to use components:**
-- You need fine-grained control over the release process
-- You want to create custom workflows
+- You need fine-grained control over builds, publishing, validation, or security checks
+- You want to compose custom workflows around leaf helpers
 - You're integrating with existing CI/CD pipelines
 
 **When to use orchestrators:**
@@ -188,6 +197,9 @@ with:
   linters.commitlint: true         # Deprecated v3.0: migrate to devbasecheck
   linters.licenselint: true        # Deprecated v3.0: migrate to devbasecheck
   linters.dependencyreview: true   # Dependency vulnerability review
+  security.sast-opengrep: true     # OpenGrep SAST (default; set false to opt out)
+  security.sast-opengrep-rules: p/default
+  security.sast-opengrep-fail-on-severity: high
   linters.megalint: true           # Deprecated v3.0: migrate to devbasecheck
   linters.publiccodelint: false    # Publiccode.yml validation
   linters.devbasecheck: false      # Recommended: replaces deprecated linters
@@ -196,7 +208,7 @@ with:
   reusable-ci-ref: v2.7.0           # Match the pinned workflow release
 ```
 
-**Outputs:** The quality stage exposes `stage-ran`, `stage-result`, and `result-json` with per-check target results. See [PR Quality Stage Result Contract](workflows.md#pr-quality-stage-result-contract) for the full schema.
+**Behavior:** The orchestrator remains the supported entrypoint. Internally it delegates to the quality stage, which writes a normalized manifest consumed by the top-level PR summary. See [PR Quality Stage Result Contract](workflows.md#pr-quality-stage-result-contract) for the internal schema.
 
 ### Lint Workflows
 
@@ -255,6 +267,19 @@ Reviews dependencies for known vulnerabilities.
 ```yaml
 uses: ./.github/workflows/security-dependency-review.yml
 ```
+
+#### `security-opengrep.yml`
+Runs OpenGrep SAST and emits portable outputs for GitHub and GitLab-style integrations.
+```yaml
+uses: ./.github/workflows/security-opengrep.yml
+with:
+  opengrep-rules: p/default
+  fail-on-severity: high
+```
+
+The workflow runs directly on the GitHub runner in this branch. The runtime container path is introduced later on the GitLab prep branch.
+
+SARIF is always generated and saved as a workflow artifact. To publish results into GitHub Security / Code Scanning, configure the org or repo secret `SARIF_UPLOAD_TOKEN` and pass secrets with `secrets: inherit`.
 
 #### `security-openssf-scorecard.yml`
 Generates OpenSSF security scorecard for the repository.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -71,7 +71,7 @@ Note: GitHub Packages uploads use `GITHUB_TOKEN` (automatic, no configuration ne
 
 ### SARIF_UPLOAD_TOKEN
 
-Used for uploading security scan results (SARIF) to GitHub Code Scanning. Without this token, scans still run and SARIF files are saved as workflow artifacts, but results won't appear in the Code Scanning tab.
+Used for uploading security scan results (SARIF) to GitHub Security / Code Scanning. Without this token, scans still run, SARIF is still generated, and SARIF files are still saved as workflow artifacts, but results won't appear in Security / Code Scanning.
 
 **Option A — GitHub App (recommended):**
 - Create a GitHub App with `code_scanning_alerts: write` repository permission
@@ -93,10 +93,11 @@ Results appear in the Code Scanning tab grouped by category:
 |----------|---------|------|
 | `megalinter` | MegaLinter | PR quality checks |
 | `dependency-review` | Trivy | PR dependency scan |
+| `opengrep-sast` | OpenGrep | PR SAST scan |
 | `scorecard` | OpenSSF Scorecard | Scheduled analysis |
 | `container-scan` | Trivy | Release container build |
 
-SARIF files are also saved as workflow artifacts (`sarif-megalinter`, `sarif-dependency-review`, `sarif-scorecard`, `sarif-container-scan`) regardless of whether the token is configured.
+SARIF files are also saved as workflow artifacts (`sarif-megalinter`, `sarif-dependency-review`, `sarif-opengrep`, `sarif-scorecard`, `sarif-container-scan`) regardless of whether the token is configured.
 
 ---
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -168,7 +168,6 @@ lint-rust:
 
 # Remove by deleting the task - automatically excluded
 ```
-
 ## Artifact Verification Methods
 
 | Artifact Type | Verification Methods | Security Level | What It Proves |

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -114,7 +114,7 @@ Both metadata lines optional. Defaults to task name if missing.
 
 The workflow generates a formatted summary showing:
 
-```markdown
+````markdown
 # 🔍 Just+Mise Linting Results
 
 **Linters Run:** 8
@@ -131,17 +131,15 @@ The workflow generates a formatted summary showing:
 
 ## ❌ Failed Linters
 
-<details>
-<summary>❌ markdown - Click to expand error details</summary>
+### markdown
 
-**Exit code:** 1
+**Exit code:** 1  
 **Duration:** 0.01s
 
-### Output
-```
-README.md:45 - Line too long (found 120, expected 100)
+#### Output
 ```text
-</details>
+README.md:45 - Line too long (found 120, expected 100)
+```
 
 ---
 
@@ -149,7 +147,7 @@ README.md:45 - Line too long (found 120, expected 100)
 
 **Total Duration:** 11.89s
 **Pass:** ✅ 6 | **Fail:** ❌ 2
-```
+````
 
 #### How It Works
 

--- a/examples/gradle-app/pullrequest-workflow.yml
+++ b/examples/gradle-app/pullrequest-workflow.yml
@@ -32,6 +32,10 @@ jobs:
       linters.commitlint: false
       linters.licenselint: false
       linters.megalint: false
+      # OpenGrep SAST is enabled by default. Opt out if needed:
+      # security.sast-opengrep: false
+      # security.sast-opengrep-rules: p/default
+      # security.sast-opengrep-fail-on-severity: high
 
   # Optional: Add project-specific tests
   # test:

--- a/examples/maven-app/pullrequest-workflow.yml
+++ b/examples/maven-app/pullrequest-workflow.yml
@@ -32,6 +32,10 @@ jobs:
       linters.commitlint: false
       linters.licenselint: false
       linters.megalint: false
+      # OpenGrep SAST is enabled by default. Opt out if needed:
+      # security.sast-opengrep: false
+      # security.sast-opengrep-rules: p/default
+      # security.sast-opengrep-fail-on-severity: high
 
   # Optional: Add project-specific tests
   # test:

--- a/examples/npm-app/pullrequest-workflow.yml
+++ b/examples/npm-app/pullrequest-workflow.yml
@@ -32,6 +32,10 @@ jobs:
       linters.commitlint: false
       linters.licenselint: false
       linters.megalint: false
+      # OpenGrep SAST is enabled by default. Opt out if needed:
+      # security.sast-opengrep: false
+      # security.sast-opengrep-rules: p/default
+      # security.sast-opengrep-fail-on-severity: high
 
   # Optional: Add project-specific tests
   # test:

--- a/scripts/ci/env.sh
+++ b/scripts/ci/env.sh
@@ -11,7 +11,7 @@
 #   source "$(dirname "$0")/../ci/env.sh"
 #
 # Exported variables:
-#   CI_PLATFORM    CI platform identifier (github, gitlab, etc.)
+#   CI_PLATFORM    CI platform identifier (github, etc.)
 #   CI_COMMIT      Commit SHA being built
 #   CI_REPO        Repository identifier (org/repo)
 #   CI_RUN_ID      Unique run/pipeline identifier
@@ -23,6 +23,9 @@
 #   CI_SERVER_URL  Base URL of the CI server
 #   CI_RUN_URL     Direct URL to the current run/pipeline
 #   CI_TEMP_DIR    Writable temp directory for tool installs
+#   CI_OUTPUT      Generic output file path for scalar job outputs
+#   CI_SUMMARY     Generic markdown summary file path
+#   CI_RESULTS_DIR Directory for structured JSON result manifests
 
 [[ -n "${_CI_ENV_LOADED:-}" ]] && return 0
 _CI_ENV_LOADED=1
@@ -37,17 +40,29 @@ if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
   CI_PR_BASE_REF="${GITHUB_BASE_REF:-}"
   CI_REF_NAME="${GITHUB_REF_NAME:-}"
   CI_REF="${GITHUB_REF:-}"
-  CI_SERVER_URL="https://github.com"
-  CI_RUN_URL="https://github.com/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}"
+  CI_SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+  CI_RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}"
   CI_TEMP_DIR="${RUNNER_TEMP:-/tmp}"
-
-elif [[ "${GITLAB_CI:-}" == "true" ]]; then
-  # GitLab CI mappings — future task
-  CI_PR_BASE_REF="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}"
-  CI_TEMP_DIR="${CI_BUILDS_DIR:-/tmp}"
+  CI_OUTPUT="${CI_OUTPUT:-${GITHUB_OUTPUT:-}}"
+  CI_SUMMARY="${CI_SUMMARY:-${GITHUB_STEP_SUMMARY:-}}"
+  CI_RESULTS_DIR="${CI_RESULTS_DIR:-.ci-results}"
 
 else
-  CI_TEMP_DIR="${TMPDIR:-/tmp}"
+  CI_PLATFORM="${CI_PLATFORM:-local}"
+  CI_COMMIT="${CI_COMMIT:-}"
+  CI_REPO="${CI_REPO:-}"
+  CI_RUN_ID="${CI_RUN_ID:-}"
+  CI_ACTOR="${CI_ACTOR:-}"
+  CI_BRANCH="${CI_BRANCH:-}"
+  CI_PR_BASE_REF="${CI_PR_BASE_REF:-}"
+  CI_REF_NAME="${CI_REF_NAME:-}"
+  CI_REF="${CI_REF:-}"
+  CI_SERVER_URL="${CI_SERVER_URL:-}"
+  CI_RUN_URL="${CI_RUN_URL:-}"
+  CI_TEMP_DIR="${CI_TEMP_DIR:-${TMPDIR:-/tmp}}"
+  CI_OUTPUT="${CI_OUTPUT:-}"
+  CI_SUMMARY="${CI_SUMMARY:-}"
+  CI_RESULTS_DIR="${CI_RESULTS_DIR:-.ci-results}"
 fi
 
-export CI_PLATFORM CI_COMMIT CI_REPO CI_RUN_ID CI_ACTOR CI_BRANCH CI_PR_BASE_REF CI_REF_NAME CI_REF CI_SERVER_URL CI_RUN_URL CI_TEMP_DIR
+export CI_PLATFORM CI_COMMIT CI_REPO CI_RUN_ID CI_ACTOR CI_BRANCH CI_PR_BASE_REF CI_REF_NAME CI_REF CI_SERVER_URL CI_RUN_URL CI_TEMP_DIR CI_OUTPUT CI_SUMMARY CI_RESULTS_DIR

--- a/scripts/ci/install-opengrep.sh
+++ b/scripts/ci/install-opengrep.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+# SPDX-License-Identifier: CC0-1.0
+
+# Install OpenGrep if not already available.
+#
+# Usage: source this file, then call install_opengrep
+#   source "$(dirname "$0")/../ci/install-opengrep.sh"
+#   install_opengrep
+
+# renovate: datasource=github-releases depName=opengrep/opengrep
+readonly OPENGREP_VERSION="v1.18.0"
+
+resolve_opengrep_dist() {
+  local os arch dist=""
+  os="${OS:-$(uname -s)}"
+  arch="${ARCH:-$(uname -m)}"
+
+  case "$os" in
+  Linux)
+    if ldd /bin/sh 2>&1 | grep -qi musl; then
+      case "$arch" in
+      x86_64 | amd64) dist="opengrep_musllinux_x86" ;;
+      aarch64 | arm64) dist="opengrep_musllinux_aarch64" ;;
+      esac
+    else
+      case "$arch" in
+      x86_64 | amd64) dist="opengrep_manylinux_x86" ;;
+      aarch64 | arm64) dist="opengrep_manylinux_aarch64" ;;
+      esac
+    fi
+    ;;
+  Darwin)
+    case "$arch" in
+    x86_64 | amd64) dist="opengrep_osx_x86" ;;
+    aarch64 | arm64) dist="opengrep_osx_arm64" ;;
+    esac
+    ;;
+  esac
+
+  if [[ -z "$dist" ]]; then
+    printf "ERROR: Unsupported OpenGrep platform: %s/%s\n" "$os" "$arch" >&2
+    return 1
+  fi
+
+  printf '%s' "$dist"
+}
+
+install_opengrep() {
+  if command -v opengrep &>/dev/null; then
+    printf "OpenGrep already installed: %s\n\n" "$(opengrep --version 2>/dev/null | tr -d '\r')"
+    return 0
+  fi
+
+  local install_dir dist asset_url
+  install_dir="${CI_TEMP_DIR:-/tmp}/opengrep-bin"
+  mkdir -p "$install_dir"
+
+  dist="$(resolve_opengrep_dist)" || return 1
+  asset_url="https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/${dist}"
+
+  printf "Installing OpenGrep (version: %s)...\n" "$OPENGREP_VERSION"
+  if ! curl -fsSL -o "$install_dir/opengrep" "$asset_url"; then
+    printf "ERROR: Failed to download OpenGrep from %s\n" "$asset_url" >&2
+    return 1
+  fi
+
+  chmod +x "$install_dir/opengrep"
+  export PATH="${install_dir}:$PATH"
+
+  if ! command -v opengrep &>/dev/null; then
+    printf "ERROR: OpenGrep binary not found after install\n" >&2
+    return 1
+  fi
+
+  printf "OpenGrep installed successfully: %s\n\n" "$(opengrep --version 2>/dev/null | tr -d '\r')"
+}

--- a/scripts/ci/manifest.sh
+++ b/scripts/ci/manifest.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+# SPDX-License-Identifier: CC0-1.0
+
+# File-based CI manifest helpers.
+#
+# Usage: source this file from scripts that need to persist structured data
+# between jobs or stages.
+
+ci_results_dir() {
+  local dir="${CI_RESULTS_DIR:-.ci-results}"
+  mkdir -p "$dir"
+  printf '%s' "$dir"
+}
+
+ci_manifest_path() {
+  local name="$1"
+  printf '%s/%s.json' "$(ci_results_dir)" "$name"
+}
+
+ci_write_manifest() {
+  local name="$1"
+  local content="$2"
+  local path
+
+  path="$(ci_manifest_path "$name")"
+  printf '%s\n' "$content" >"$path"
+  printf '%s' "$path"
+}
+
+ci_read_manifest() {
+  local name="$1"
+  local path
+
+  path="$(ci_manifest_path "$name")"
+  if [[ -f "$path" ]]; then
+    cat "$path"
+  fi
+}
+
+ci_stage_result_path() {
+  local stage="$1"
+  ci_manifest_path "${stage}-result"
+}
+
+ci_write_stage_result() {
+  local stage="$1"
+  local content="$2"
+  ci_write_manifest "${stage}-result" "$content"
+}
+
+ci_read_stage_result() {
+  local stage="$1"
+  ci_read_manifest "${stage}-result"
+}
+
+ci_json_input() {
+  local inline_json="${1:-}"
+  local path="${2:-}"
+
+  if [[ -n "$path" && -f "$path" ]]; then
+    tr -d '\n' <"$path"
+  else
+    printf '%s' "$inline_json"
+  fi
+}

--- a/scripts/ci/output.sh
+++ b/scripts/ci/output.sh
@@ -37,29 +37,34 @@
 #   CI_PRERELEASE_SUFFIX_REGEX     Prerelease suffix validation regex
 #   CI_CHECKSUMS_FILE              Canonical checksums filename
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/env.sh"
+
 # Write a key=value pair to workflow outputs
 ci_output() {
   local key="$1"
   local value="$2"
-  local output_file="${GITHUB_OUTPUT:-${CI_OUTPUT:-}}"
+  local output_file
+  output_file="$(ci_output_file)"
 
-  if [[ -n "$output_file" ]]; then
+  if [[ "$output_file" != "/dev/null" ]]; then
     printf '%s=%s\n' "$key" "$value" >>"$output_file"
   fi
 }
 
 # Return the output file path (for scripts that redirect stdout in bulk)
 ci_output_file() {
-  printf '%s' "${GITHUB_OUTPUT:-${CI_OUTPUT:-/dev/null}}"
+  printf '%s' "${CI_OUTPUT:-/dev/null}"
 }
 
 # Write a multiline value to workflow outputs (reads from stdin)
 ci_output_multiline() {
   local key="$1"
-  local output_file="${GITHUB_OUTPUT:-${CI_OUTPUT:-}}"
+  local output_file
+  output_file="$(ci_output_file)"
   local delimiter="EOF_${RANDOM}_${RANDOM}"
 
-  if [[ -n "$output_file" ]]; then
+  if [[ "$output_file" != "/dev/null" ]]; then
     printf '%s<<%s\n' "$key" "$delimiter" >>"$output_file"
     cat >>"$output_file"
     printf '%s\n' "$delimiter" >>"$output_file"
@@ -68,13 +73,14 @@ ci_output_multiline() {
 
 # Append content to step summary (reads from stdin)
 ci_summary() {
-  local summary_file="${GITHUB_STEP_SUMMARY:-${CI_SUMMARY:-/dev/null}}"
+  local summary_file
+  summary_file="$(ci_summary_file)"
   cat >>"$summary_file"
 }
 
 # Return the summary file path (for scripts that use >> directly)
 ci_summary_file() {
-  printf '%s' "${GITHUB_STEP_SUMMARY:-${CI_SUMMARY:-/dev/null}}"
+  printf '%s' "${CI_SUMMARY:-/dev/null}"
 }
 
 # Print JSON boolean: "true" or "false"
@@ -84,7 +90,7 @@ ci_json_bool() {
 
 # Log an error message (platform-aware annotation)
 ci_log_error() {
-  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  if [[ "${CI_PLATFORM:-local}" == "github" ]]; then
     printf '::error::%s\n' "$1"
   else
     printf 'ERROR: %s\n' "$1" >&2
@@ -93,7 +99,7 @@ ci_log_error() {
 
 # Log a warning message (platform-aware annotation)
 ci_log_warning() {
-  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  if [[ "${CI_PLATFORM:-local}" == "github" ]]; then
     printf '::warning::%s\n' "$1"
   else
     printf 'WARNING: %s\n' "$1" >&2

--- a/scripts/plan/write-pr-interface.sh
+++ b/scripts/plan/write-pr-interface.sh
@@ -9,18 +9,23 @@ source "$SCRIPT_DIR/../ci/output.sh"
 
 main() {
   local swift_bool="false"
+  local sast_opengrep_bool
+
   if [[ "${LINTER_SWIFTFORMAT}" == "true" || "${LINTER_SWIFTLINT}" == "true" ]]; then
     swift_bool="true"
   fi
 
-  local pr_context pr_policy
-  pr_context=$(printf '{"project_type":"%s","base_branch":"%s","reusable_ci_ref":"%s"}' \
-    "$PROJECT_TYPE" "${BASE_BRANCH:-}" "$REUSABLE_CI_REF")
+  sast_opengrep_bool="$(ci_json_bool "${SAST_OPENGREP:-false}")"
 
-  pr_policy=$(printf '{"commitlint":%s,"licenselint":%s,"dependencyreview":%s,"megalint":%s,"publiccodelint":%s,"devbasecheck":%s,"swiftformat":%s,"swiftlint":%s,"swift":%s}' \
+  local pr_context pr_policy
+  pr_context=$(printf '{"project_type":"%s","base_branch":"%s","reusable_ci_ref":"%s","sast_opengrep_rules":"%s","sast_opengrep_fail_on_severity":"%s"}' \
+    "$PROJECT_TYPE" "${BASE_BRANCH:-}" "$REUSABLE_CI_REF" "${SAST_OPENGREP_RULES:-p/default}" "${SAST_OPENGREP_FAIL_ON_SEVERITY:-high}")
+
+  pr_policy=$(printf '{"commitlint":%s,"licenselint":%s,"dependencyreview":%s,"sastopengrep":%s,"megalint":%s,"publiccodelint":%s,"devbasecheck":%s,"swiftformat":%s,"swiftlint":%s,"swift":%s}' \
     "$(ci_json_bool "$LINTER_COMMITLINT")" \
     "$(ci_json_bool "$LINTER_LICENSLINT")" \
     "$(ci_json_bool "$LINTER_DEPENDENCYREVIEW")" \
+    "$sast_opengrep_bool" \
     "$(ci_json_bool "$LINTER_MEGALINT")" \
     "$(ci_json_bool "$LINTER_PUBLICCODELINT")" \
     "$(ci_json_bool "$LINTER_DEVBASECHECK")" \

--- a/scripts/security/enrich-github-sarif.sh
+++ b/scripts/security/enrich-github-sarif.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+# SPDX-License-Identifier: CC0-1.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../ci/output.sh"
+
+main() {
+  local sarif_file tmp_file
+  sarif_file="${SARIF_FILE:-}"
+  tmp_file=""
+
+  if [[ -z "$sarif_file" ]]; then
+    ci_log_error "SARIF_FILE environment variable is required"
+    exit 1
+  fi
+
+  if [[ ! -f "$sarif_file" ]]; then
+    ci_log_warning "SARIF file not found, skipping GitHub enrichment: ${sarif_file}"
+    exit 0
+  fi
+
+  if ! command -v jq &>/dev/null; then
+    ci_log_warning "jq not available, skipping GitHub SARIF enrichment"
+    exit 0
+  fi
+
+  tmp_file="$(mktemp "${CI_TEMP_DIR:-/tmp}/opengrep-sarif.XXXXXX")"
+  trap '[[ -n "${tmp_file:-}" ]] && rm -f "$tmp_file"' EXIT
+
+  jq '
+    (.runs[]?.results[]?) |= (
+      if ((.partialFingerprints.primaryLocationLineHash? // "") != "") then
+        .
+      else
+        .partialFingerprints = (
+          (.partialFingerprints // {}) + {
+            "primaryLocationLineHash": (
+              .fingerprints["matchBasedId/v1"]
+              // ([
+                .ruleId // "rule",
+                .locations[0].physicalLocation.artifactLocation.uri // "unknown",
+                ((.locations[0].physicalLocation.region.startLine // 0) | tostring),
+                .message.text // ""
+              ] | join("|"))
+            )
+          }
+        )
+      end
+    )
+  ' "$sarif_file" >"$tmp_file"
+
+  mv "$tmp_file" "$sarif_file"
+  printf "Enriched SARIF with GitHub partialFingerprints: %s\n" "$sarif_file"
+}
+
+main "$@"

--- a/scripts/security/run-opengrep.sh
+++ b/scripts/security/run-opengrep.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+# SPDX-License-Identifier: CC0-1.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../ci/env.sh"
+source "$SCRIPT_DIR/../ci/output.sh"
+source "$SCRIPT_DIR/../ci/install-opengrep.sh"
+
+readonly DEFAULT_OPENGREP_CONFIG="p/default"
+readonly DEFAULT_OPENGREP_FAIL_ON_SEVERITY="high"
+readonly DEFAULT_OPENGREP_TARGET_PATH="."
+readonly DEFAULT_OPENGREP_JSON_FILE="opengrep-results.json"
+readonly DEFAULT_OPENGREP_SARIF_FILE="opengrep-results.sarif"
+readonly DEFAULT_OPENGREP_TEXT_FILE="opengrep-results.txt"
+readonly DEFAULT_OPENGREP_GITLAB_SAST_FILE="opengrep-results.gitlab-sast.json"
+
+trim_whitespace() {
+  local value="${1:-}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+normalize_fail_on_severity() {
+  case "${1,,}" in
+  none | off | never)
+    printf 'none'
+    ;;
+  low | info)
+    printf 'low'
+    ;;
+  medium | moderate | warning)
+    printf 'medium'
+    ;;
+  high | critical | error)
+    printf 'high'
+    ;;
+  *)
+    ci_log_error "Unsupported OPENGREP_FAIL_ON_SEVERITY value: $1"
+    return 1
+    ;;
+  esac
+}
+
+build_config_args() {
+  local raw_configs="$1"
+  local config trimmed
+
+  CONFIG_ARGS=()
+  IFS=',' read -r -a raw_list <<<"$raw_configs"
+  for config in "${raw_list[@]}"; do
+    trimmed="$(trim_whitespace "$config")"
+    [[ -z "$trimmed" ]] && continue
+    CONFIG_ARGS+=(--config "$trimmed")
+  done
+
+  if [[ ${#CONFIG_ARGS[@]} -eq 0 ]]; then
+    ci_log_error "At least one OpenGrep config is required"
+    return 1
+  fi
+}
+
+count_occurrences() {
+  local file="$1"
+  local needle="$2"
+  local count="0"
+
+  if [[ -f "$file" ]]; then
+    count="$(grep -o "$needle" "$file" 2>/dev/null | wc -l | tr -d '[:space:]')"
+  fi
+
+  printf '%s' "${count:-0}"
+}
+
+has_findings_meeting_threshold() {
+  local threshold="$1"
+  local findings_total="$2"
+  local error_total="$3"
+  local warning_total="$4"
+
+  case "$threshold" in
+  none) printf 'false' ;;
+  low)
+    if [[ "$findings_total" -gt 0 ]]; then printf 'true'; else printf 'false'; fi
+    ;;
+  medium)
+    if [[ "$error_total" -gt 0 || "$warning_total" -gt 0 ]]; then printf 'true'; else printf 'false'; fi
+    ;;
+  high)
+    if [[ "$error_total" -gt 0 ]]; then printf 'true'; else printf 'false'; fi
+    ;;
+  *)
+    printf 'false'
+    ;;
+  esac
+}
+
+code_scanning_label() {
+  case "${CI_PLATFORM:-local}" in
+  github)
+    if [[ "${HAS_SARIF_UPLOAD_TOKEN:-false}" == "true" || -n "${SARIF_UPLOAD_TOKEN:-}" ]]; then
+      printf 'SARIF generated, upload configured'
+    else
+      printf 'SARIF generated, upload not configured'
+    fi
+    ;;
+  gitlab)
+    printf 'GitLab SAST artifact generated'
+    ;;
+  *)
+    printf 'Portable artifacts only'
+    ;;
+  esac
+}
+
+workflow_run_label() {
+  if [[ -n "${CI_RUN_URL:-}" ]]; then
+    printf '[View workflow run](%s)' "$CI_RUN_URL"
+  else
+    printf 'n/a'
+  fi
+}
+
+artifacts_label() {
+  printf '%s' "\`opengrep-results.sarif\`, \`opengrep-results.json\`, \`opengrep-results.txt\`, \`opengrep-results.gitlab-sast.json\`"
+}
+
+code_scanning_note() {
+  case "${CI_PLATFORM:-local}" in
+  github)
+    if [[ "${HAS_SARIF_UPLOAD_TOKEN:-false}" == "true" || -n "${SARIF_UPLOAD_TOKEN:-}" ]]; then
+      printf 'SARIF will be uploaded to Security / Code Scanning after the scan step completes.'
+    else
+      printf 'SARIF is still generated and saved as a workflow artifact. Configure SARIF_UPLOAD_TOKEN to publish results in Security / Code Scanning.'
+    fi
+    ;;
+  gitlab)
+    printf 'A GitLab SAST report is generated alongside the portable artifacts.'
+    ;;
+  *)
+    printf 'Portable artifacts are generated without platform-native upload.'
+    ;;
+  esac
+}
+
+write_failure_summary() {
+  local config="$1"
+  local target_path="$2"
+  local scan_exit="$3"
+
+  {
+    printf "## OpenGrep SAST\n\n"
+    printf 'OpenGrep exited with status %s before a complete result set was produced.\n\n' "$scan_exit"
+    printf "| Property | Value |\n"
+    printf "|----------|-------|\n"
+    printf "| Rules | %s |\n" "$config"
+    printf "| Target | %s |\n" "$target_path"
+    printf "| Security / Code Scanning | %s |\n" "$(code_scanning_label)"
+    printf "| Workflow Run | %s |\n" "$(workflow_run_label)"
+    printf "| Artifacts | %s |\n" "$(artifacts_label)"
+    printf "| Scan Result | failure |\n"
+  } >>"$(ci_summary_file)"
+}
+
+write_scan_summary() {
+  local config="$1"
+  local target_path="$2"
+  local fail_on_severity="$3"
+  local findings_total="$4"
+  local error_total="$5"
+  local warning_total="$6"
+  local info_total="$7"
+  local threshold_failure="$8"
+  local text_file="$9"
+  local scan_result summary_line
+
+  if [[ "$threshold_failure" == "true" ]]; then
+    scan_result="failure"
+    summary_line="Blocked by findings meeting threshold \`${fail_on_severity}\`."
+  elif [[ "$findings_total" -gt 0 ]]; then
+    scan_result="success"
+    summary_line="Completed with findings below threshold \`${fail_on_severity}\`."
+  else
+    scan_result="success"
+    summary_line="Passed with \`0\` findings."
+  fi
+
+  {
+    printf "## OpenGrep SAST\n\n"
+    printf "%s\n\n" "$summary_line"
+    printf "| Property | Value |\n"
+    printf "|----------|-------|\n"
+    printf '| Rules | %s |\n' "$config"
+    printf '| Target | %s |\n' "$target_path"
+    printf "| Findings | %s |\n" "$findings_total"
+    printf "| Fail Threshold | %s |\n" "$fail_on_severity"
+    printf "| Security / Code Scanning | %s |\n" "$(code_scanning_label)"
+    printf "| Workflow Run | %s |\n" "$(workflow_run_label)"
+    printf "| Artifacts | %s |\n" "$(artifacts_label)"
+    printf "| Scan Result | %s |\n" "$scan_result"
+    printf "\n%s\n" "$(code_scanning_note)"
+
+    if [[ "$findings_total" -gt 0 ]]; then
+      printf "\n| Severity | Count |\n"
+      printf "|----------|-------|\n"
+      printf "| ERROR | %s |\n" "$error_total"
+      printf "| WARNING | %s |\n" "$warning_total"
+      printf "| INFO | %s |\n" "$info_total"
+    fi
+
+    if [[ "$findings_total" -gt 0 && -f "$text_file" ]]; then
+      printf "\n<details>\n<summary>OpenGrep findings excerpt</summary>\n\n<pre>\n"
+      sed -n '1,120p' "$text_file"
+      printf "\n</pre>\n</details>\n"
+    fi
+  } >>"$(ci_summary_file)"
+}
+
+main() {
+  local config fail_on_severity target_path
+  local json_file sarif_file text_file gitlab_sast_file
+  local scan_exit findings_total error_total warning_total info_total threshold_failure
+
+  config="${OPENGREP_CONFIG:-$DEFAULT_OPENGREP_CONFIG}"
+  fail_on_severity="$(normalize_fail_on_severity "${OPENGREP_FAIL_ON_SEVERITY:-$DEFAULT_OPENGREP_FAIL_ON_SEVERITY}")"
+  target_path="${OPENGREP_TARGET_PATH:-$DEFAULT_OPENGREP_TARGET_PATH}"
+  json_file="${OPENGREP_JSON_FILE:-$DEFAULT_OPENGREP_JSON_FILE}"
+  sarif_file="${OPENGREP_SARIF_FILE:-$DEFAULT_OPENGREP_SARIF_FILE}"
+  text_file="${OPENGREP_TEXT_FILE:-$DEFAULT_OPENGREP_TEXT_FILE}"
+  gitlab_sast_file="${OPENGREP_GITLAB_SAST_FILE:-$DEFAULT_OPENGREP_GITLAB_SAST_FILE}"
+
+  build_config_args "$config"
+  install_opengrep
+
+  local -a scan_args
+  scan_args=(
+    scan
+    --quiet
+    --disable-version-check
+    --exclude .github-shared
+    --taint-intrafile
+    --dataflow-traces
+    --json-output "$json_file"
+    --sarif-output "$sarif_file"
+    --text-output "$text_file"
+    --gitlab-sast-output "$gitlab_sast_file"
+  )
+  scan_args+=("${CONFIG_ARGS[@]}")
+  scan_args+=("$target_path")
+
+  printf "Running OpenGrep with config '%s' on '%s'...\n" "$config" "$target_path"
+  set +e
+  PYTHONWARNINGS="ignore:RequestsDependencyWarning" opengrep "${scan_args[@]}"
+  scan_exit=$?
+  set -e
+
+  if [[ "$scan_exit" -ne 0 ]]; then
+    write_failure_summary "$config" "$target_path" "$scan_exit"
+    exit "$scan_exit"
+  fi
+
+  findings_total="$(count_occurrences "$json_file" '"check_id":')"
+  error_total="$(count_occurrences "$json_file" '"severity":"ERROR"')"
+  warning_total="$(count_occurrences "$json_file" '"severity":"WARNING"')"
+  info_total="$(count_occurrences "$json_file" '"severity":"INFO"')"
+  threshold_failure="$(has_findings_meeting_threshold "$fail_on_severity" "$findings_total" "$error_total" "$warning_total")"
+
+  write_scan_summary "$config" "$target_path" "$fail_on_severity" "$findings_total" "$error_total" "$warning_total" "$info_total" "$threshold_failure" "$text_file"
+
+  ci_output "opengrep-result" "$(if [[ "$threshold_failure" == "true" ]]; then printf 'failure'; else printf 'success'; fi)"
+  ci_output "opengrep-findings-total" "$findings_total"
+  ci_output "opengrep-findings-error" "$error_total"
+  ci_output "opengrep-findings-warning" "$warning_total"
+  ci_output "opengrep-findings-info" "$info_total"
+  ci_output "opengrep-fail-threshold" "$fail_on_severity"
+
+  if [[ "$threshold_failure" == "true" ]]; then
+    ci_log_error "OpenGrep found findings meeting fail threshold '${fail_on_severity}'"
+    exit 1
+  fi
+
+  printf "OpenGrep completed successfully with %s findings\n" "$findings_total"
+}
+
+main "$@"

--- a/scripts/summary/write-pr-quality-stage-result.sh
+++ b/scripts/summary/write-pr-quality-stage-result.sh
@@ -6,21 +6,23 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../ci/output.sh"
+source "$SCRIPT_DIR/../ci/manifest.sh"
 source "$SCRIPT_DIR/../ci/stage-result.sh"
 
 main() {
-  local commitlint_result licenselint_result dependencyreview_result megalint_result publiccodelint_result devbasecheck_result swift_result
+  local commitlint_result licenselint_result dependencyreview_result sastopengrep_result megalint_result publiccodelint_result devbasecheck_result swift_result
 
   commitlint_result="$(ci_normalize_result "${COMMITLINT_RESULT:-skipped}")"
   licenselint_result="$(ci_normalize_result "${LICENSLINT_RESULT:-skipped}")"
   dependencyreview_result="$(ci_normalize_result "${DEPENDENCYREVIEW_RESULT:-skipped}")"
+  sastopengrep_result="$(ci_normalize_result "${SASTOPENGREP_RESULT:-skipped}")"
   megalint_result="$(ci_normalize_result "${MEGALINT_RESULT:-skipped}")"
   publiccodelint_result="$(ci_normalize_result "${PUBLICCODELINT_RESULT:-skipped}")"
   devbasecheck_result="$(ci_normalize_result "${DEVBASECHECK_RESULT:-skipped}")"
   swift_result="$(ci_normalize_result "${SWIFT_RESULT:-skipped}")"
 
   local stage_result
-  stage_result="$(ci_aggregate_results "$commitlint_result" "$licenselint_result" "$dependencyreview_result" "$megalint_result" "$publiccodelint_result" "$devbasecheck_result" "$swift_result")"
+  stage_result="$(ci_aggregate_results "$commitlint_result" "$licenselint_result" "$dependencyreview_result" "$sastopengrep_result" "$megalint_result" "$publiccodelint_result" "$devbasecheck_result" "$swift_result")"
 
   effective_result() {
     if [[ "$1" == "true" ]]; then printf '%s' "$2"; else printf 'skipped'; fi
@@ -31,11 +33,13 @@ main() {
     "commitlint:$(effective_result "${COMMITLINT_ENABLED:-false}" "$commitlint_result")" \
     "licenselint:$(effective_result "${LICENSLINT_ENABLED:-false}" "$licenselint_result")" \
     "dependencyreview:$(effective_result "${DEPENDENCYREVIEW_ENABLED:-false}" "$dependencyreview_result")" \
+    "sastopengrep:$(effective_result "${SASTOPENGREP_ENABLED:-false}" "$sastopengrep_result")" \
     "megalint:$(effective_result "${MEGALINT_ENABLED:-false}" "$megalint_result")" \
     "publiccodelint:$(effective_result "${PUBLICCODELINT_ENABLED:-false}" "$publiccodelint_result")" \
     "devbasecheck:$(effective_result "${DEVBASECHECK_ENABLED:-false}" "$devbasecheck_result")" \
     "swift:$(effective_result "${SWIFT_ENABLED:-false}" "$swift_result")")"
   result_json="$(ci_stage_result_json "pr-quality" "$stage_result" "true" "$targets_json")"
+  ci_write_stage_result "pr-quality" "$result_json" >/dev/null
 
   ci_output "stage-ran" "true"
   ci_output "stage-result" "$stage_result"

--- a/scripts/summary/write-pr-summary.sh
+++ b/scripts/summary/write-pr-summary.sh
@@ -7,22 +7,26 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../ci/output.sh"
 source "$SCRIPT_DIR/../ci/env.sh"
+source "$SCRIPT_DIR/../ci/manifest.sh"
 
 main() {
   local run_time short_sha
   local commitlint_result licenselint_result dependencyreview_result
-  local megalint_result publiccodelint_result devbasecheck_result swift_result
+  local sastopengrep_result megalint_result publiccodelint_result devbasecheck_result swift_result
+  local quality_stage_result_json
 
   run_time=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
   short_sha="${CI_COMMIT:0:7}"
+  quality_stage_result_json="$(ci_json_input "${QUALITY_STAGE_RESULT_JSON:-}" "${QUALITY_STAGE_RESULT_PATH:-}")"
 
-  commitlint_result="$(ci_json_value "$QUALITY_STAGE_RESULT_JSON" commitlint)"
-  licenselint_result="$(ci_json_value "$QUALITY_STAGE_RESULT_JSON" licenselint)"
-  dependencyreview_result="$(ci_json_value "$QUALITY_STAGE_RESULT_JSON" dependencyreview)"
-  megalint_result="$(ci_json_value "$QUALITY_STAGE_RESULT_JSON" megalint)"
-  publiccodelint_result="$(ci_json_value "$QUALITY_STAGE_RESULT_JSON" publiccodelint)"
-  devbasecheck_result="$(ci_json_value "$QUALITY_STAGE_RESULT_JSON" devbasecheck)"
-  swift_result="$(ci_json_value "$QUALITY_STAGE_RESULT_JSON" swift)"
+  commitlint_result="$(ci_json_value "$quality_stage_result_json" commitlint)"
+  licenselint_result="$(ci_json_value "$quality_stage_result_json" licenselint)"
+  dependencyreview_result="$(ci_json_value "$quality_stage_result_json" dependencyreview)"
+  sastopengrep_result="$(ci_json_value "$quality_stage_result_json" sastopengrep)"
+  megalint_result="$(ci_json_value "$quality_stage_result_json" megalint)"
+  publiccodelint_result="$(ci_json_value "$quality_stage_result_json" publiccodelint)"
+  devbasecheck_result="$(ci_json_value "$quality_stage_result_json" devbasecheck)"
+  swift_result="$(ci_json_value "$quality_stage_result_json" swift)"
 
   cat >>"$(ci_summary_file)" <<EOF
 # Pull Request Summary
@@ -42,6 +46,7 @@ main() {
 | Commit Lint | $(ci_status_icon "$commitlint_result") |
 | License Lint | $(ci_status_icon "$licenselint_result") |
 | Dependency Review | $(ci_status_icon "$dependencyreview_result") |
+| OpenGrep SAST | $(ci_status_icon "$sastopengrep_result") |
 | MegaLinter | $(ci_status_icon "$megalint_result") |
 | Publiccode Lint | $(ci_status_icon "$publiccodelint_result") |
 | Devbase Check | $(ci_status_icon "$devbasecheck_result") |

--- a/tests/ci/manifest.bats
+++ b/tests/ci/manifest.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+# shellcheck disable=SC1090,SC2016,SC2030,SC2031,SC2119,SC2120,SC2155
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+# SPDX-License-Identifier: CC0-1.0
+
+bats_require_minimum_version 1.13.0
+
+load "${BATS_TEST_DIRNAME}/../libs/bats-support/load.bash"
+load "${BATS_TEST_DIRNAME}/../libs/bats-assert/load.bash"
+load "${BATS_TEST_DIRNAME}/../libs/bats-file/load.bash"
+load "${BATS_TEST_DIRNAME}/../test_helper.bash"
+
+setup() {
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+@test "manifest helper writes and reads stage result in default directory" {
+  run --separate-stderr bash -c 'source "$1"; path="$(ci_write_stage_result "build" "{\"result\":\"success\"}")"; printf "path=%s\ncontent=%s\n" "$path" "$(ci_read_stage_result "build")"' _ "$SCRIPTS_DIR/ci/manifest.sh"
+
+  assert_success
+  assert_output --partial "path=.ci-results/build-result.json"
+  assert_output --partial 'content={"result":"success"}'
+  assert_file_exist "$TEST_DIR/.ci-results/build-result.json"
+}
+
+@test "manifest helper respects CI_RESULTS_DIR override" {
+  export CI_RESULTS_DIR="custom-results"
+
+  run --separate-stderr bash -c 'source "$1"; printf "%s\n" "$(ci_write_manifest "custom" "{\"ok\":true}")"' _ "$SCRIPTS_DIR/ci/manifest.sh"
+
+  assert_success
+  assert_output "custom-results/custom.json"
+  assert_file_exist "$TEST_DIR/custom-results/custom.json"
+}

--- a/tests/plan/write-pr-interface.bats
+++ b/tests/plan/write-pr-interface.bats
@@ -31,6 +31,9 @@ set_all_linters_enabled() {
   export LINTER_DEVBASECHECK="true"
   export LINTER_SWIFTFORMAT="true"
   export LINTER_SWIFTLINT="true"
+  export SAST_OPENGREP="true"
+  export SAST_OPENGREP_RULES="p/default"
+  export SAST_OPENGREP_FAIL_ON_SEVERITY="high"
 }
 
 set_all_linters_disabled() {
@@ -45,6 +48,9 @@ set_all_linters_disabled() {
   export LINTER_DEVBASECHECK="false"
   export LINTER_SWIFTFORMAT="false"
   export LINTER_SWIFTLINT="false"
+  export SAST_OPENGREP="false"
+  export SAST_OPENGREP_RULES="p/default"
+  export SAST_OPENGREP_FAIL_ON_SEVERITY="high"
 }
 
 @test "write-pr-interface succeeds with all linters enabled" {
@@ -60,6 +66,8 @@ set_all_linters_disabled() {
   export PROJECT_TYPE="npm"
   export BASE_BRANCH="develop"
   export REUSABLE_CI_REF="v2.5.0"
+  export SAST_OPENGREP_RULES="rules/opengrep.yml"
+  export SAST_OPENGREP_FAIL_ON_SEVERITY="medium"
 
   run_script "plan/write-pr-interface.sh"
   assert_success
@@ -68,6 +76,8 @@ set_all_linters_disabled() {
   assert_output --partial '"project_type":"npm"'
   assert_output --partial '"base_branch":"develop"'
   assert_output --partial '"reusable_ci_ref":"v2.5.0"'
+  assert_output --partial '"sast_opengrep_rules":"rules/opengrep.yml"'
+  assert_output --partial '"sast_opengrep_fail_on_severity":"medium"'
 }
 
 @test "pr-policy-json has correct boolean values when all linters enabled" {
@@ -80,6 +90,7 @@ set_all_linters_disabled() {
   assert_output --partial '"commitlint":true'
   assert_output --partial '"licenselint":true'
   assert_output --partial '"dependencyreview":true'
+  assert_output --partial '"sastopengrep":true'
   assert_output --partial '"megalint":true'
   assert_output --partial '"publiccodelint":true'
   assert_output --partial '"devbasecheck":true'
@@ -128,5 +139,5 @@ set_all_linters_disabled() {
   assert_success
 
   run get_github_output "pr-policy-json"
-  assert_output '{"commitlint":false,"licenselint":false,"dependencyreview":false,"megalint":false,"publiccodelint":false,"devbasecheck":false,"swiftformat":false,"swiftlint":false,"swift":false}'
+  assert_output '{"commitlint":false,"licenselint":false,"dependencyreview":false,"sastopengrep":false,"megalint":false,"publiccodelint":false,"devbasecheck":false,"swiftformat":false,"swiftlint":false,"swift":false}'
 }

--- a/tests/security/enrich-github-sarif.bats
+++ b/tests/security/enrich-github-sarif.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+
+# shellcheck disable=SC1090,SC2016,SC2030,SC2031,SC2119,SC2120,SC2155
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+# SPDX-License-Identifier: CC0-1.0
+
+bats_require_minimum_version 1.13.0
+
+load "${BATS_TEST_DIRNAME}/../libs/bats-support/load.bash"
+load "${BATS_TEST_DIRNAME}/../libs/bats-assert/load.bash"
+load "${BATS_TEST_DIRNAME}/../libs/bats-file/load.bash"
+load "${BATS_TEST_DIRNAME}/../test_helper.bash"
+
+setup() {
+  common_setup
+  export SARIF_FILE="$TEST_DIR/results.sarif"
+}
+
+teardown() {
+  common_teardown
+}
+
+@test "adds partialFingerprints when missing" {
+  create_test_file_heredoc "$SARIF_FILE" <<'EOF'
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "results": [
+        {
+          "ruleId": "rules.test",
+          "fingerprints": {
+            "matchBasedId/v1": "stable-fingerprint"
+          },
+          "message": {
+            "text": "test finding"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/app.js"
+                },
+                "region": {
+                  "startLine": 10
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+  run_script "security/enrich-github-sarif.sh"
+
+  assert_success
+  assert_file_contains "$SARIF_FILE" '"partialFingerprints"'
+  assert_file_contains "$SARIF_FILE" '"primaryLocationLineHash": "stable-fingerprint"'
+}
+
+@test "skips enrichment when SARIF file is missing" {
+  export SARIF_FILE="$TEST_DIR/missing.sarif"
+
+  run_script "security/enrich-github-sarif.sh"
+
+  assert_success
+  assert_stderr_contains "skipping GitHub enrichment"
+}

--- a/tests/security/run-opengrep.bats
+++ b/tests/security/run-opengrep.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+
+# shellcheck disable=SC1090,SC2016,SC2030,SC2031,SC2119,SC2120,SC2155
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+# SPDX-License-Identifier: CC0-1.0
+
+bats_require_minimum_version 1.13.0
+
+load "${BATS_TEST_DIRNAME}/../libs/bats-support/load.bash"
+load "${BATS_TEST_DIRNAME}/../libs/bats-assert/load.bash"
+load "${BATS_TEST_DIRNAME}/../libs/bats-file/load.bash"
+load "${BATS_TEST_DIRNAME}/../test_helper.bash"
+
+setup() {
+  common_setup_with_github_env
+  export OPENGREP_CONFIG="p/default"
+  export OPENGREP_TARGET_PATH="."
+  export OPENGREP_TEST_JSON='{"version":"1.18.0","results":[],"errors":[],"paths":{"scanned":["src/app.js"]}}'
+  export OPENGREP_TEST_SARIF='{"version":"2.1.0","runs":[]}'
+  export OPENGREP_TEST_TEXT='No findings'
+  export OPENGREP_TEST_GITLAB_SAST='{"version":"15.0.4","scan":{"start_time":"2026-01-01T00:00:00","end_time":"2026-01-01T00:00:00","analyzer":{"id":"opengrep","name":"Opengrep","version":"1.18.0","vendor":{"name":"Opengrep"}},"scanner":{"id":"opengrep","name":"Opengrep","version":"1.18.0","vendor":{"name":"Opengrep"}},"status":"success","type":"sast"},"vulnerabilities":[]}'
+  export OPENGREP_TEST_EXIT_CODE="0"
+
+  create_mock_binary "opengrep" '
+if [[ "${1:-}" == "--version" ]]; then
+  printf "opengrep %s\n" "${OPENGREP_TEST_VERSION:-1.18.0}"
+  exit 0
+fi
+json_file=""
+sarif_file=""
+text_file=""
+gitlab_sast_file=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json-output) json_file="$2"; shift 2 ;;
+    --sarif-output) sarif_file="$2"; shift 2 ;;
+    --text-output) text_file="$2"; shift 2 ;;
+    --gitlab-sast-output) gitlab_sast_file="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf "%s" "$OPENGREP_TEST_JSON" > "$json_file"
+printf "%s" "$OPENGREP_TEST_SARIF" > "$sarif_file"
+printf "%s" "$OPENGREP_TEST_TEXT" > "$text_file"
+printf "%s" "$OPENGREP_TEST_GITLAB_SAST" > "$gitlab_sast_file"
+exit "$OPENGREP_TEST_EXIT_CODE"
+'
+  use_mock_path
+}
+
+teardown() {
+  common_teardown
+}
+
+@test "writes OpenGrep outputs and succeeds with no findings" {
+  export OPENGREP_FAIL_ON_SEVERITY="high"
+
+  run_script "security/run-opengrep.sh"
+
+  assert_success
+  assert_file_exist "$TEST_DIR/opengrep-results.json"
+  assert_file_exist "$TEST_DIR/opengrep-results.sarif"
+  assert_file_exist "$TEST_DIR/opengrep-results.gitlab-sast.json"
+  assert_summary_contains "OpenGrep SAST"
+  assert_summary_contains 'Passed with `0` findings.'
+  assert_summary_contains "| Security / Code Scanning | SARIF generated, upload not configured |"
+  assert_summary_contains "test-owner/test-repo/actions/runs/12345"
+  assert_summary_contains 'Configure `SARIF_UPLOAD_TOKEN` to publish results in Security / Code Scanning.'
+  run get_github_output "opengrep-result"
+  assert_output "success"
+}
+
+@test "fails when warning findings meet medium threshold" {
+  export OPENGREP_FAIL_ON_SEVERITY="medium"
+  export OPENGREP_TEST_JSON='{"version":"1.18.0","results":[{"check_id":"rule.warning","extra":{"severity":"WARNING"}},{"check_id":"rule.info","extra":{"severity":"INFO"}}],"errors":[]}'
+  export OPENGREP_TEST_TEXT='warning finding'
+
+  run_script "security/run-opengrep.sh"
+
+  assert_failure
+  assert_summary_contains 'Blocked by findings meeting threshold `medium`.'
+  assert_summary_contains "| Findings | 2 |"
+  assert_summary_contains "| WARNING | 1 |"
+  run get_github_output "opengrep-result"
+  assert_output "failure"
+}

--- a/tests/summary/write-pr-quality-stage-result.bats
+++ b/tests/summary/write-pr-quality-stage-result.bats
@@ -23,6 +23,7 @@ teardown() {
   export COMMITLINT_RESULT="success"
   export LICENSLINT_RESULT="success"
   export DEPENDENCYREVIEW_RESULT="success"
+  export SASTOPENGREP_RESULT="success"
   export MEGALINT_RESULT="success"
   export PUBLICCODELINT_RESULT="success"
   export DEVBASECHECK_RESULT="success"
@@ -30,6 +31,7 @@ teardown() {
   export COMMITLINT_ENABLED="true"
   export LICENSLINT_ENABLED="true"
   export DEPENDENCYREVIEW_ENABLED="true"
+  export SASTOPENGREP_ENABLED="true"
   export MEGALINT_ENABLED="true"
   export PUBLICCODELINT_ENABLED="true"
   export DEVBASECHECK_ENABLED="true"
@@ -43,6 +45,8 @@ teardown() {
 
   run get_github_output "stage-result"
   assert_output "success"
+
+  assert_stage_result_manifest_matches_output "pr-quality"
 }
 
 @test "all default to success when no env vars set" {
@@ -124,6 +128,7 @@ teardown() {
   export COMMITLINT_ENABLED="true"
   export LICENSLINT_ENABLED="false"
   export DEPENDENCYREVIEW_ENABLED="false"
+  export SASTOPENGREP_ENABLED="false"
   export MEGALINT_ENABLED="false"
   export PUBLICCODELINT_ENABLED="false"
   export DEVBASECHECK_ENABLED="false"
@@ -136,6 +141,7 @@ teardown() {
   assert_output --partial '"commitlint":"success"'
   assert_output --partial '"licenselint":"skipped"'
   assert_output --partial '"dependencyreview":"skipped"'
+  assert_output --partial '"sastopengrep":"skipped"'
   assert_output --partial '"megalint":"skipped"'
 }
 
@@ -143,10 +149,12 @@ teardown() {
   export COMMITLINT_RESULT="success"
   export LICENSLINT_RESULT="failure"
   export DEPENDENCYREVIEW_RESULT="cancelled"
+  export SASTOPENGREP_RESULT="failure"
   export MEGALINT_RESULT="success"
   export COMMITLINT_ENABLED="true"
   export LICENSLINT_ENABLED="true"
   export DEPENDENCYREVIEW_ENABLED="true"
+  export SASTOPENGREP_ENABLED="true"
   export MEGALINT_ENABLED="true"
   export PUBLICCODELINT_ENABLED="false"
   export DEVBASECHECK_ENABLED="false"
@@ -159,6 +167,7 @@ teardown() {
   assert_output --partial '"commitlint":"success"'
   assert_output --partial '"licenselint":"failure"'
   assert_output --partial '"dependencyreview":"cancelled"'
+  assert_output --partial '"sastopengrep":"failure"'
   assert_output --partial '"megalint":"success"'
 }
 
@@ -167,6 +176,7 @@ teardown() {
   export COMMITLINT_ENABLED="true"
   export LICENSLINT_ENABLED="false"
   export DEPENDENCYREVIEW_ENABLED="false"
+  export SASTOPENGREP_ENABLED="false"
   export MEGALINT_ENABLED="false"
   export PUBLICCODELINT_ENABLED="false"
   export DEVBASECHECK_ENABLED="false"
@@ -182,6 +192,7 @@ teardown() {
   assert_output --partial '"commitlint":"success"'
   assert_output --partial '"licenselint":"skipped"'
   assert_output --partial '"dependencyreview":"skipped"'
+  assert_output --partial '"sastopengrep":"skipped"'
   assert_output --partial '"megalint":"skipped"'
   assert_output --partial '"publiccodelint":"skipped"'
   assert_output --partial '"devbasecheck":"skipped"'

--- a/tests/summary/write-pr-summary.bats
+++ b/tests/summary/write-pr-summary.bats
@@ -20,11 +20,24 @@ setup() {
   export GITHUB_REPOSITORY="org/repo"
   export GITHUB_RUN_ID="12345"
   export PROJECT_TYPE="maven"
-  export QUALITY_STAGE_RESULT_JSON='{"targets":{"commitlint":"success","licenselint":"success","dependencyreview":"skipped","megalint":"success","publiccodelint":"success","devbasecheck":"skipped","swift":"skipped"}}'
+  export QUALITY_STAGE_RESULT_JSON='{"targets":{"commitlint":"success","licenselint":"success","dependencyreview":"skipped","sastopengrep":"success","megalint":"success","publiccodelint":"success","devbasecheck":"skipped","swift":"skipped"}}'
 }
 
 teardown() {
   common_teardown
+}
+
+@test "write-pr-summary reads quality result from manifest path when provided" {
+  create_test_file "${TEST_DIR}/quality.json" '{"targets":{"commitlint":"failure","licenselint":"success","dependencyreview":"skipped","sastopengrep":"failure","megalint":"success","publiccodelint":"success","devbasecheck":"skipped","swift":"skipped"}}'
+  export QUALITY_STAGE_RESULT_PATH="${TEST_DIR}/quality.json"
+  export QUALITY_STAGE_RESULT_JSON='{"targets":{"commitlint":"success","licenselint":"success","dependencyreview":"success","sastopengrep":"success","megalint":"failure","publiccodelint":"success","devbasecheck":"success","swift":"success"}}'
+
+  run_script "summary/write-pr-summary.sh"
+
+  assert_success
+  run get_summary
+  assert_output --partial "| Commit Lint | ✗ |"
+  assert_output --partial "| OpenGrep SAST | ✗ |"
 }
 
 @test "write-pr-summary creates step summary file" {
@@ -69,6 +82,7 @@ teardown() {
   assert_summary_contains "Quality Check Status"
   assert_summary_contains "Commit Lint"
   assert_summary_contains "License Lint"
+  assert_summary_contains "OpenGrep SAST"
   assert_summary_contains "MegaLinter"
 }
 
@@ -79,17 +93,19 @@ teardown() {
   run get_summary
   assert_output --partial "| Commit Lint | ✓ |"
   assert_output --partial "| License Lint | ✓ |"
+  assert_output --partial "| OpenGrep SAST | ✓ |"
   assert_output --partial "| MegaLinter | ✓ |"
 }
 
 @test "write-pr-summary shows failure icon for failed targets" {
-  export QUALITY_STAGE_RESULT_JSON='{"targets":{"commitlint":"failure","licenselint":"success","dependencyreview":"skipped","megalint":"failure","publiccodelint":"success","devbasecheck":"skipped","swift":"skipped"}}'
+  export QUALITY_STAGE_RESULT_JSON='{"targets":{"commitlint":"failure","licenselint":"success","dependencyreview":"skipped","sastopengrep":"failure","megalint":"failure","publiccodelint":"success","devbasecheck":"skipped","swift":"skipped"}}'
 
   run_script "summary/write-pr-summary.sh"
 
   assert_success
   run get_summary
   assert_output --partial "| Commit Lint | ✗ |"
+  assert_output --partial "| OpenGrep SAST | ✗ |"
   assert_output --partial "| MegaLinter | ✗ |"
   assert_output --partial "| Dependency Review | − |"
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -184,6 +184,9 @@ init_remote_repo() {
 # Usage: setup_github_env
 setup_github_env() {
   export GITHUB_ACTIONS="true"
+  export GITHUB_SERVER_URL="https://github.com"
+  export GITHUB_REPOSITORY="test-owner/test-repo"
+  export GITHUB_RUN_ID="12345"
   export GITHUB_OUTPUT="$TEST_DIR/github_output"
   export GITHUB_STEP_SUMMARY="$TEST_DIR/step_summary.md"
   export GITHUB_ENV="$TEST_DIR/github_env"
@@ -460,6 +463,47 @@ assert_summary_contains() {
 # Usage: get_summary
 get_summary() {
   cat "$GITHUB_STEP_SUMMARY"
+}
+
+# Get manifest file path under the default CI results directory
+# Usage: get_manifest_path <name>
+get_manifest_path() {
+  local name="$1"
+  printf '%s/.ci-results/%s.json' "$TEST_DIR" "$name"
+}
+
+# Get stage result manifest file path
+# Usage: get_stage_result_manifest_path <stage>
+get_stage_result_manifest_path() {
+  local stage="$1"
+  get_manifest_path "${stage}-result"
+}
+
+# Assert that a manifest file matches a workflow output value
+# Usage: assert_manifest_equals_output <manifest_name> <output_key>
+assert_manifest_equals_output() {
+  local manifest_name="$1"
+  local output_key="$2"
+  local path expected actual
+
+  path="$(get_manifest_path "$manifest_name")"
+  assert_file_exist "$path"
+  expected="$(get_github_output "$output_key" 2>/dev/null || true)"
+  actual="$(tr -d '\n' <"$path")"
+
+  if [[ "$actual" != "$expected" ]]; then
+    printf "Expected manifest %s to equal output %s\n" "$manifest_name" "$output_key" >&2
+    printf "Expected: %s\n" "$expected" >&2
+    printf "Actual: %s\n" "$actual" >&2
+    return 1
+  fi
+}
+
+# Assert that a stage result manifest matches result-json output
+# Usage: assert_stage_result_manifest_matches_output <stage>
+assert_stage_result_manifest_matches_output() {
+  local stage="$1"
+  assert_manifest_equals_output "${stage}-result" "result-json"
 }
 
 # =============================================================================


### PR DESCRIPTION
Add OpenGrep SAST as an opt-out PR security workflow with portable outputs.

OUTPUT from a run be view here https://github.com/diggsweden/reusable-ci/actions/runs/24188661683
See the SAST job.
Also scroll down a bit and see we integrated this with the UI symmary output.

NOTE This contains two commits, whereas the first one is a cleanup that otherwise would make opengrep fail:) So when reviewing just click on second commit to get the real diff.

Here is quick AI-summary:

This PR adds OpenGrep as the new reusable SAST check in the PR flow.
The main goal is to get a real, reusable security scan into the pipeline without making the implementation GitHub-specific from the start. The scan is now part of the quality stage, enabled by default but still possible to opt out from. Results are produced in a portable way: SARIF, JSON, text, and GitLab SAST JSON.
On GitHub, the workflow gives a readable summary in the PR run and can also upload SARIF into Security / Code Scanning when SARIF_UPLOAD_TOKEN is configured. SARIF is always generated even when upload is not enabled, so the scan is still useful out of the box.
A small GitHub-specific SARIF enrichment step is included as well. It adds stable partial fingerprints so findings behave better in GitHub’s code scanning view and are easier to track across runs.
As part of introducing the scanner, the repo’s own workflow YAML had to be hardened. OpenGrep immediately flagged several existing run: steps where GitHub expressions were interpolated directly into shell. Those are now rewritten to pass values through env: instead, which is both safer and closer to what OpenGrep expects.
The PR also fixes the hidden .ci-results artifact upload in the PR flow, since those files are needed by the summary job and GitHub does not include hidden paths in uploaded artifacts unless that is explicitly enabled.
This branch is intentionally limited to the OpenGrep feature itself: scanner support, PR integration, output, and the minimum repo cleanup needed to make it pass. Follow up PR's will further pave the road for easy GitLab dual use, but that is for another discussion.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
