### PR TITLE
fix: move scorecard SARIF token to step env and guard script checkouts

### DIFF
--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Checkout reusable-ci scripts
+        if: always()
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: diggsweden/reusable-ci

--- a/.github/workflows/security-opengrep.yml
+++ b/.github/workflows/security-opengrep.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Checkout reusable-ci scripts
+        if: always()
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: diggsweden/reusable-ci

--- a/.github/workflows/security-openssf-scorecard.yml
+++ b/.github/workflows/security-openssf-scorecard.yml
@@ -53,8 +53,9 @@ jobs:
       contents: read
       # Needed for GitHub OIDC token if publish_results is true
       id-token: write
-    env:
-      SARIF_UPLOAD_TOKEN: ${{ secrets.SARIF_UPLOAD_TOKEN }}
+    # Note: scorecard-action's publish webapp forbids job-level env vars
+    # (see https://github.com/ossf/scorecard-action#workflow-restrictions).
+    # SARIF_UPLOAD_TOKEN is declared at step level on the upload step below.
     steps:
       - name: Harden GitHub runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -83,6 +84,7 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: Checkout reusable-ci scripts
+        if: success() || failure()
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: diggsweden/reusable-ci
@@ -92,6 +94,7 @@ jobs:
       - name: Upload scorecard results to Code Scanning
         if: success() || failure()
         env:
+          SARIF_UPLOAD_TOKEN: ${{ secrets.SARIF_UPLOAD_TOKEN }}
           SARIF_FILE: results.sarif
           SARIF_CATEGORY: scorecard
         run: bash .github-shared/scripts/security/upload-sarif.sh


### PR DESCRIPTION
This fixes two bugs.

Scorecard publish webapp rejects workflows with job-level env vars (ossf/scorecard-action workflow restrictions), causing the scorecard step to fail.

As a further failure it lead to cascading failure where we should always upload the result.

Improved OpenGrep and Dep review to also always run.


## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
